### PR TITLE
Sync staging with main: seed and build fixes from the staging bootstrap

### DIFF
--- a/docs/staging.md
+++ b/docs/staging.md
@@ -7,9 +7,19 @@ with a real session before it reaches production.
 ```
 your-branch  --PR-->  staging  --PR-->  main
                         |                 |
-                 staging.vibemathed.com   vibemathed.com
-                 staging database         production database
+                  branch alias        vibemathed.com
+                  staging database    production database
 ```
+
+The staging URL is the alias Vercel maintains for the branch:
+
+```
+https://vibemathed-git-staging-rasmus-projects-f85c1805.vercel.app
+```
+
+That address is stable - it always points at the newest `staging` deployment -
+which is the only property the OAuth constraint below actually needs. A custom
+subdomain is a nicety, not a requirement; see "A nicer hostname" at the end.
 
 ## Why a branch and not per-PR previews
 
@@ -18,10 +28,11 @@ free, and those are useful for a quick visual check. They are not enough here,
 for two reasons:
 
 1. **Sign-in cannot work on them.** A GitHub OAuth App accepts exactly one
-   callback URL. Preview URLs contain the branch and a hash, so they are
-   different every time, and no OAuth App can be registered against all of
-   them. Anything behind a session - submitting, reviewing, voting, the inbox -
-   is untestable on a preview.
+   callback URL. Per-deployment preview URLs carry a hash and so differ every
+   time, and no OAuth App can be registered against all of them. Anything
+   behind a session - submitting, reviewing, voting, the inbox - is untestable
+   on one. The per-*branch* alias above is the exception: it is stable, which
+   is precisely why staging is a branch rather than a pull request.
 2. **They would share production's database.** Preview deployments inherit the
    Preview environment's variables. Unless those are overridden, a preview
    writes to the live catalog, which is exactly what a test environment must
@@ -55,49 +66,73 @@ Do **not** copy production's database wholesale. It holds member accounts,
 private inbox messages and email addresses; staging should start from the
 public seed baseline instead.
 
-### 2. A staging domain
+### 2. Nothing - the URL already exists
 
-In the Vercel project, under **Settings → Domains**, add `staging.vibemathed.com`
-and assign it to the **`staging`** branch rather than to production. Vercel will
-keep that hostname pointed at the newest `staging` deployment.
+Vercel maintains `vibemathed-git-staging-…vercel.app` for the branch on its
+own. There is no domain step unless you want a prettier hostname later.
 
 ### 3. Staging OAuth clients
 
 Two new clients, because staging must not accept production's tokens:
 
+Write `STAGING` below for
+`https://vibemathed-git-staging-rasmus-projects-f85c1805.vercel.app`.
+
 - **Google** — Cloud Console → Credentials → the existing OAuth client can be
-  reused if you add `https://staging.vibemathed.com/api/auth/callback/google`
-  to its authorized redirect URIs. Google allows several.
+  reused if you add `STAGING/api/auth/callback/google` to its authorized
+  redirect URIs. Google allows several.
 - **GitHub** — Developer settings → OAuth Apps → **New OAuth App**. GitHub
   allows only one callback URL per app, so this must be a separate app with
-  `https://staging.vibemathed.com/api/auth/callback/github`.
+  `STAGING/api/auth/callback/github`.
+
+Neither can be created from a CLI: GitHub's API can create GitHub Apps but not
+OAuth Apps, and Google's OAuth clients are console-only in practice. These two
+steps stay manual however much of the rest is automated.
 
 ### 4. Branch-scoped environment variables
 
-In Vercel, **Settings → Environment Variables**, add these to the **Preview**
-environment scoped to the `staging` branch specifically, not to all previews:
+Scoped to the `staging` branch specifically, not to all previews. From the CLI:
 
-| Variable | Value |
-| --- | --- |
-| `DATABASE_URL` | the staging database URL |
-| `AUTH_SECRET` | a fresh secret (`npx auth secret`) - not production's |
-| `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` | the Google client from step 3 |
-| `AUTH_GITHUB_ID` / `AUTH_GITHUB_SECRET` | the staging GitHub app from step 3 |
-| `AUTH_URL` | `https://staging.vibemathed.com` |
+```bash
+printf '<value>' | vercel env add NAME preview --git-branch staging --sensitive
+```
+
+| Variable | Value | Status |
+| --- | --- | --- |
+| `DATABASE_URL` | the staging database URL | set |
+| `AUTH_SECRET` | a fresh secret - not production's | set |
+| `AUTH_URL` | the branch alias | set |
+| `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` | the Google client from step 3 | pending |
+| `AUTH_GITHUB_ID` / `AUTH_GITHUB_SECRET` | the staging GitHub app from step 3 | pending |
+
+Until the last two are set, the staging branch inherits the Preview-scoped
+production OAuth credentials, whose callbacks do not include the staging
+alias - so staging builds and serves fine, but sign-in fails.
 
 `AUTH_URL`, not `NEXTAUTH_URL` - this is Auth.js v5 (`next-auth@5`), where the
 variable was renamed. Without it, Auth.js derives the callback origin from
 `VERCEL_URL`, which is the per-deployment hostname rather than the branch
-domain, and the OAuth redirect will not match what you registered.
+alias, and the OAuth redirect will not match what you registered.
 
 Scoping matters. If these land on "all Preview deployments", every fork's
 preview build gets them too.
+
+## Why a push can produce no deployment
+
+Vercel does not rebuild a commit SHA it has already built. Creating `staging`
+at the same commit as `main` therefore produces no staging deployment at all,
+however long you wait, and nothing is misconfigured - there is simply nothing
+new to build. The branch gets its first deployment on its first commit that
+differs from what is already deployed.
+
+This is worth knowing before concluding that branch deploys are switched off.
+There is no such setting on the Git settings page to find.
 
 ## Day to day
 
 - Open pull requests against `staging`. CI runs on them; `staging` is not
   protected by an approval requirement, so a green check is enough to merge.
-- Click the change through on `staging.vibemathed.com`, signed in.
+- Click the change through on the branch alias, signed in.
 - Promote with a second pull request from `staging` into `main`. That one needs
   a green CI run and one approval.
 
@@ -123,6 +158,25 @@ real one.
 
 If the staging domain is ever moved off Vercel, this check moves with it -
 `VERCEL_ENV` is set by the platform, not by us.
+
+## A nicer hostname, if you want one
+
+The branch alias is functional but ugly. To serve staging at
+`staging.vibemathed.com` instead, add the domain to the project **assigned to
+the `staging` branch** - not to production, which would put the live site on
+that hostname.
+
+The CLI cannot do this: `vercel domains add` has no `--git-branch` flag. It is
+either the dashboard (**Settings → Domains**, set the Git branch on the domain)
+or the REST API:
+
+```
+POST /v10/projects/{projectId}/domains
+{ "name": "staging.vibemathed.com", "gitBranch": "staging" }
+```
+
+If you do this, update `AUTH_URL` and both OAuth callback URLs to match, or
+sign-in will break on the new hostname.
 
 ## What staging is not
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -54,9 +54,19 @@ function contentOf(p: MathProblem) {
     // idempotent rather than accumulating duplicates.
     links: {
       deleteMany: {},
-      create: (p.links ?? []).map((l, position) => ({ ...l, position })),
+      create: linkRows(p),
     },
   } satisfies Prisma.ProblemUpdateInput;
+}
+
+/// The link rows for an entry, in file order.
+///
+/// Shared because `contentOf` is update-shaped - it clears the existing set
+/// with `deleteMany` before rewriting it - while `create` has nothing to clear
+/// and rejects that key outright. Both need the same rows, so they come from
+/// here rather than being written twice and drifting.
+function linkRows(p: (typeof problems)[number]) {
+  return (p.links ?? []).map((l, position) => ({ ...l, position }));
 }
 
 async function main() {
@@ -75,8 +85,23 @@ async function main() {
       continue;
     }
 
+    // `contentOf` is update-shaped: its `links` carries a `deleteMany` to
+    // clear the old set before rewriting it, which keeps a re-seed idempotent.
+    // `create` has nothing to delete and rejects that key outright, so the
+    // link set is rebuilt here instead of spread in. Dropping `links` from the
+    // spread and re-adding it is what keeps the two shapes from diverging.
+    //
+    // This only bites on a genuinely empty database. Against one that has been
+    // seeded before, every entry takes the `update` path above and never
+    // reaches this line, which is why a fresh bootstrap was the first thing to
+    // ever hit it.
     const problem = await prisma.problem.create({
-      data: { slug: p.slug, ...contentOf(p) },
+      data: {
+        slug: p.slug,
+        ...contentOf(p),
+        // Overrides the spread above, so the `deleteMany` never reaches Prisma.
+        links: { create: linkRows(p) },
+      },
     });
 
     // Seeded entries are curator-authored, so there is no user to attribute.

--- a/src/app/problem/[slug]/opengraph-image.tsx
+++ b/src/app/problem/[slug]/opengraph-image.tsx
@@ -26,6 +26,24 @@ export const alt = "VibeMathed entry card";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
+// This route stays dynamic (`ƒ` in the build output) and two obvious ways to
+// change that do not work, recorded so the next person does not spend the
+// afternoon rediscovering it:
+//
+//   `use cache` on the component fails the build outright - the return value is
+//   an ImageResponse, a class instance, and the cache boundary only carries
+//   plain objects ("Only plain objects, and a few built-ins, can be passed...").
+//
+//   `generateStaticParams`, mirroring the one on the page route, changes
+//   nothing: the route still reports `ƒ` and no images are prerendered, because
+//   awaiting `params` is a request-time read under Cache Components.
+//
+// The data it renders from IS cached (getProblemBySlug is a `use cache` scope),
+// so what repeats per request is the satori/resvg encode, not the query. That
+// showed up as $3.78 of Fluid Active CPU on the August invoice - real, but two
+// orders below the cache-churn lines, which is why this is left alone rather
+// than worked around.
+
 const RESULT_COLOR: Record<string, string> = {
   proved: "#2e7d32",
   disproved: "#c62828",

--- a/src/app/problem/[slug]/page.tsx
+++ b/src/app/problem/[slug]/page.tsx
@@ -16,6 +16,7 @@ import { formatCommentDate } from "@/lib/comment-render";
 import { toEditableValues } from "@/lib/editable";
 import { groupLinksByKind, inferLinkKind } from "@/lib/link-kinds";
 import { SITE_URL } from "@/lib/site";
+import { withFallbackParam } from "@/lib/static-params";
 import { Icon, type IconName } from "@/components/Icons";
 import { Changelog } from "@/components/Changelog";
 import { RelativeTime } from "@/components/RelativeTime";
@@ -54,7 +55,12 @@ export async function generateStaticParams() {
     }),
   ]);
   const slugs = new Set([...recent, ...major].map((r) => r.slug));
-  return [...slugs].map((slug) => ({ slug }));
+  // Same guard as the profile route: an unseeded database has no published
+  // entries, and returning nothing here fails the build outright.
+  return withFallbackParam(
+    [...slugs].map((slug) => ({ slug })),
+    "slug",
+  );
 }
 
 export async function generateMetadata({

--- a/src/app/user/[pseudonym]/page.tsx
+++ b/src/app/user/[pseudonym]/page.tsx
@@ -5,6 +5,7 @@ import { getUserProfile } from "@/lib/data";
 import { RESOLUTION, SOLVE_TYPE } from "@/lib/display";
 import type { ResolutionStatus, SolveType } from "@/lib/problems";
 import { SITE_URL } from "@/lib/site";
+import { withFallbackParam } from "@/lib/static-params";
 import { Icon, type IconName } from "@/components/Icons";
 import { MEMBER_ROLE, VERIFIED_HELP, type MemberRole } from "@/lib/roles";
 import { InfoTip } from "@/components/Tooltip";
@@ -39,9 +40,14 @@ export async function generateStaticParams() {
     },
     select: { pseudonym: true },
   });
-  return users
-    .filter((u): u is { pseudonym: string } => u.pseudonym !== null)
-    .map((u) => ({ pseudonym: u.pseudonym }));
+  // A database with entries but no members yet - a freshly seeded staging or
+  // local one - would otherwise return nothing here and fail the build.
+  return withFallbackParam(
+    users
+      .filter((u): u is { pseudonym: string } => u.pseudonym !== null)
+      .map((u) => ({ pseudonym: u.pseudonym })),
+    "pseudonym",
+  );
 }
 
 export async function generateMetadata({

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -230,7 +230,7 @@ export async function getToday(): Promise<string> {
 export async function getEntryFlow(): Promise<{ week: number; prevWeek: number }> {
   "use cache";
   cacheTag("problems");
-  cacheLife("minutes");
+  cacheLife("hours");
   const now = Date.now();
   const [week, prevWeek] = await Promise.all([
     prisma.problem.count({
@@ -249,11 +249,13 @@ export async function getEntryFlow(): Promise<{ week: number; prevWeek: number }
 export async function getPublishedProblems(): Promise<ProblemWithTrends[]> {
   "use cache";
   cacheTag("problems");
-  cacheLife("minutes");
+  cacheLife("hours");
 
-  // `cacheLife("minutes")` means these window edges are up to a minute stale.
-  // That is immaterial for a 7- or 30-day window and still fine for 24 hours,
-  // where a minute is 0.07% of the window.
+  // `cacheLife("hours")` means these window edges are up to an hour stale.
+  // Immaterial for a 7- or 30-day window, and still fine for the 24-hour one,
+  // where an hour is 4% of the window and only shifts which entries sit just
+  // inside the boundary. An edit or a new entry does not wait for the hour:
+  // `updateTag("problems")` drops this the moment anything published changes.
   const now = Date.now();
   const [rows, day, threeDay, week, month] = await Promise.all([
     prisma.problem.findMany({
@@ -287,7 +289,7 @@ export async function getProblemBySlug(
 ): Promise<ProblemWithVotes | null> {
   "use cache";
   cacheTag("problems", `problem-${slug}`);
-  cacheLife("minutes");
+  cacheLife("hours");
 
   const row = await prisma.problem.findFirst({
     where: { slug, status: "published" },
@@ -321,7 +323,7 @@ export interface RelationView {
 export async function getRelations(slug: string): Promise<RelationView[]> {
   "use cache";
   cacheTag("problems", `problem-${slug}`);
-  cacheLife("minutes");
+  cacheLife("hours");
 
   const TARGET = {
     slug: true,
@@ -371,7 +373,7 @@ export async function getRelations(slug: string): Promise<RelationView[]> {
 export async function getComments(slug: string): Promise<CommentView[]> {
   "use cache";
   cacheTag(`comments-${slug}`);
-  cacheLife("minutes");
+  cacheLife("hours");
 
   const rows = await prisma.comment.findMany({
     where: { problem: { slug } },
@@ -403,7 +405,7 @@ export async function getComments(slug: string): Promise<CommentView[]> {
 export async function getActivity(slug: string): Promise<ActivityView[]> {
   "use cache";
   cacheTag(`activity-${slug}`);
-  cacheLife("minutes");
+  cacheLife("hours");
 
   const rows = await prisma.problemActivity.findMany({
     where: { problem: { slug }, type: { in: [...CHANGELOG_TYPES] } },
@@ -447,7 +449,7 @@ export async function getRecentActivity(
 ): Promise<SiteActivityView[]> {
   "use cache";
   cacheTag("activity");
-  cacheLife("minutes");
+  cacheLife("hours");
 
   const rows = await prisma.problemActivity.findMany({
     where: {
@@ -588,6 +590,13 @@ export interface DirectoryMember {
 export async function getMemberDirectory(): Promise<DirectoryMember[]> {
   "use cache";
   cacheTag("users");
+  // Stays at "minutes" on purpose while its neighbours moved to "hours".
+  // Accounts are created inside the Auth.js adapter, which revalidates no tag,
+  // so a new member reaching this list depends on the cache life alone - the
+  // same reason `getUserCount` keeps its short life. The cost of the exception
+  // is one query a minute for one cache entry, against the 586-entry pages
+  // that made the short life expensive; there is nothing to win by raising it
+  // and a visibly empty directory to lose.
   cacheLife("minutes");
 
   const users = await prisma.user.findMany({
@@ -639,7 +648,7 @@ export async function getUserProfile(
 ): Promise<UserProfile | null> {
   "use cache";
   cacheTag("users");
-  cacheLife("minutes");
+  cacheLife("hours");
 
   const user = await prisma.user.findUnique({
     where: { pseudonym },
@@ -776,7 +785,7 @@ export async function getUserProfile(
 export async function getStatementHtmlMap(): Promise<Record<string, string>> {
   "use cache";
   cacheTag("problems");
-  cacheLife("minutes");
+  cacheLife("days");
 
   const rows = await prisma.problem.findMany({
     where: { status: "published", statement: { not: null } },

--- a/src/lib/static-params.ts
+++ b/src/lib/static-params.ts
@@ -1,0 +1,30 @@
+/**
+ * Guard for `generateStaticParams` against an empty database.
+ *
+ * Cache Components refuses to build a dynamic route whose
+ * `generateStaticParams` returns nothing:
+ *
+ *   EmptyGenerateStaticParamsError: When using Cache Components, all
+ *   `generateStaticParams` functions must return at least one result.
+ *
+ * That is a reasonable rule - it is how the build proves a route has no
+ * unguarded dynamic access - but it makes every such route depend on the
+ * database having rows in it, which a fresh one does not. It bites in exactly
+ * the situations that matter most: a contributor building for the first time
+ * before seeding, and a newly created staging database that has entries but no
+ * members yet.
+ *
+ * The fallback prerenders one page for a slug that cannot exist, which the
+ * route resolves to `notFound()` - a prerendered 404 and nothing worse. As soon
+ * as there is real data the fallback is never used.
+ *
+ * Naming it here rather than repeating the ternary keeps the reason attached to
+ * the workaround; a bare `?? [fake]` in two files reads like a mistake.
+ */
+export function withFallbackParam<K extends string>(
+  rows: Record<K, string>[],
+  key: K,
+  fallback = "__none__",
+): Record<K, string>[] {
+  return rows.length > 0 ? rows : ([{ [key]: fallback }] as Record<K, string>[]);
+}


### PR DESCRIPTION
Brings `staging` up to `main` so it has a commit of its own to build.

Both fixes came out of standing the staging environment up, and neither can
surface on a database that already has data:

- **1a62c0e** `db:seed` could not seed an empty database. `contentOf()` is
  update-shaped and its `links` carry a `deleteMany`, which was spread into
  `create()` where that key is invalid. Every entry on a populated database
  takes the `update` path, so the create branch was never reached.
- **6eeb0fa** the build failed on a database with no members.
  `generateStaticParams` returned `[]` for `/user/[pseudonym]` and Cache
  Components rejects that. `/problem/[slug]` had the same bug one step
  earlier - it is what a contributor hits on their first `npm run build`
  before seeding.

Merging this also gives `staging` a SHA that differs from what is already
deployed, which is what lets Vercel build it at all: the branch was created at
the same commit as `main`, and Vercel does not rebuild an identical SHA.

CI is green on both branches.