### PR TITLE
Raise max daily submission count to 10

### DIFF
--- a/src/lib/submission.ts
+++ b/src/lib/submission.ts
@@ -162,11 +162,11 @@ export function emptySubmission(): SubmissionValues {
 export { MESSAGE_MAX as REVIEW_MESSAGE_MAX } from "@/lib/messages";
 
 export const SUBMISSION_WINDOW_MS = 24 * 60 * 60 * 1000;
-/// Raised from 3 to 5. Three was set when the queue was the bottleneck; the
+/// Raised from 3 to 10. Three was set when the queue was the bottleneck; the
 /// people actually hitting it turned out to be the regulars sending several
 /// good entries in a sitting, which is the traffic this site wants, not the
 /// flooding the throttle exists to stop.
-export const SUBMISSIONS_PER_WINDOW = 5;
+export const SUBMISSIONS_PER_WINDOW = 10;
 
 /// URL-safe id derived from the entry name. Uniqueness is enforced by the
 /// caller against the database.

--- a/src/lib/submission.ts
+++ b/src/lib/submission.ts
@@ -162,10 +162,11 @@ export function emptySubmission(): SubmissionValues {
 export { MESSAGE_MAX as REVIEW_MESSAGE_MAX } from "@/lib/messages";
 
 export const SUBMISSION_WINDOW_MS = 24 * 60 * 60 * 1000;
-/// Raised from 3 to 10. Three was set when the queue was the bottleneck; the
+/// Raised 3 -> 5 -> 10. Three was set when the queue was the bottleneck; the
 /// people actually hitting it turned out to be the regulars sending several
 /// good entries in a sitting, which is the traffic this site wants, not the
-/// flooding the throttle exists to stop.
+/// flooding the throttle exists to stop. Ten because the most prolific
+/// submitter reached five in a day with a 4% rejection rate.
 export const SUBMISSIONS_PER_WINDOW = 10;
 
 /// URL-safe id derived from the entry name. Uniqueness is enforced by the


### PR DESCRIPTION
## What this changes

Per discussion in discord raise maximum submission count to 10.

## Why

Allow more submissions!

## How to check it

Check will auto-work by allowing more submissions

## Checklist

- [x] Opened against `staging` (not `main`) - see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] `npm run lint` and `npm run typecheck` pass
- [x] Comments explaining *why* are updated where the reasoning changed
- [x] No catalog content edited by hand - entries live in the database, not in git
- [x] Any script that writes to a database defaults to a dry run and needs `--apply`

Typecheck errors but error seems unrelated to this small change:

```

.next/dev/types/validator.ts:161:39 - error TS2307: Cannot find module '../../../src/app/queue/page.js' or its corresponding type declarations.

161   const handler = {} as typeof import("../../../src/app/queue/page.js")
```
