### PR TITLE
Add on-demand LaTeX previews to authoring fields

### DIFF
--- a/src/components/CommentsSection.tsx
+++ b/src/components/CommentsSection.tsx
@@ -6,7 +6,8 @@
 // static shell and get indexed. This component layers the interactive parts on
 // top: posting, replying, voting, editing your own, deleting your own. Server
 // actions return the re-rendered HTML for a comment, so edits show their math
-// immediately without a page reload and without shipping KaTeX to the browser.
+// immediately without a page reload. The composer lazy-loads browser KaTeX
+// only if its LaTeX preview tab is opened.
 //
 // Threads. The server sends one flat list with a parentId per comment; the
 // tree is built here (src/lib/comment-tree.ts) and re-sorted when the reader
@@ -15,7 +16,7 @@
 // phone would otherwise be a one-word column - and past that depth each reply
 // says who it answers instead.
 
-import { useMemo, useRef, useState, useTransition } from "react";
+import { useId, useMemo, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import type { VoteKind } from "@prisma/client";
 import {
@@ -37,6 +38,7 @@ import {
 } from "@/lib/comment-tree";
 import { useViewer } from "@/components/ViewerProvider";
 import { Icon } from "@/components/Icons";
+import { TeXPreviewTextarea } from "@/components/TeXPreviewTextarea";
 import { useBeforePaint } from "@/lib/before-paint";
 
 const textareaClass =
@@ -100,6 +102,7 @@ function Composer({
   // Open only while the caret sits directly after a just-typed ":".
   const [picker, setPicker] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
+  const textareaId = useId();
   const empty = text.trim().length === 0;
   const tooLong = text.trim().length > COMMENT_MAX_LENGTH;
 
@@ -132,22 +135,26 @@ function Composer({
 
   return (
     <div className="relative">
-      <textarea
-        ref={taRef}
+      <TeXPreviewTextarea
+        id={textareaId}
+        label="Comment"
+        textareaRef={taRef}
         value={text}
-        onChange={(e) => {
-          const v = e.target.value;
+        onChange={(value, event) => {
           // Insertion only: deleting back onto a ":" should not spring the
           // picker open under the reader's cursor.
-          const typed = v.length > text.length;
-          setText(v);
-          setPicker(typed && v.slice(0, e.target.selectionStart).endsWith(":"));
+          const typed = value.length > text.length;
+          setText(value);
+          setPicker(
+            typed && value.slice(0, event.target.selectionStart).endsWith(":"),
+          );
         }}
         onBlur={() => setPicker(false)}
         autoFocus={autoFocus}
         placeholder={placeholder ?? "Add a comment. Math works: wrap it in $…$ or $$…$$."}
-        aria-label="Comment"
         className={textareaClass}
+        rows={3}
+        heightClass="min-h-[96px]"
         onKeyDown={(e) => {
           // Ctrl/Cmd+Enter submits, matching most comment boxes.
           if ((e.ctrlKey || e.metaKey) && e.key === "Enter" && !empty && !tooLong) {

--- a/src/components/EntryFields.tsx
+++ b/src/components/EntryFields.tsx
@@ -97,6 +97,7 @@ export function EntryFields({
                   onChange={(next) => onChange(spec.key, next)}
                   className={controlClass}
                   label={spec.label}
+                  monospace
                 />
               ) : (
                 <textarea

--- a/src/components/EntryFields.tsx
+++ b/src/components/EntryFields.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from "react";
 import { charLength } from "@/lib/char-length";
 import { LinkRows } from "@/components/LinkRows";
 import { RelationRows } from "@/components/RelationRows";
+import { TeXPreviewTextarea } from "@/components/TeXPreviewTextarea";
 
 export interface RenderableField {
   key: string;
@@ -37,6 +38,7 @@ export function EntryFields({
   idPrefix,
   renderAfter,
   ownSlug,
+  texPreview,
 }: {
   fields: RenderableField[];
   values: Record<string, string>;
@@ -51,6 +53,9 @@ export function EntryFields({
   /// search results. Absent on the submission form, which has no slug yet -
   /// and no relations field either.
   ownSlug?: string;
+  /// Opt every textarea in this field set into the Text / LaTeX preview
+  /// control. The submission form enables it; edit dialogs remain unchanged.
+  texPreview?: boolean;
 }) {
   return (
     <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2">
@@ -85,13 +90,23 @@ export function EntryFields({
                 onChange={(next) => onChange(spec.key, next)}
               />
             ) : spec.kind === "textarea" ? (
-              <textarea
-                id={id}
-                value={value}
-                rows={3}
-                onChange={(e) => onChange(spec.key, e.target.value)}
-                className={`${controlClass} mt-1 resize-y`}
-              />
+              texPreview ? (
+                <TeXPreviewTextarea
+                  id={id}
+                  value={value}
+                  onChange={(next) => onChange(spec.key, next)}
+                  className={controlClass}
+                  label={spec.label}
+                />
+              ) : (
+                <textarea
+                  id={id}
+                  value={value}
+                  rows={3}
+                  onChange={(e) => onChange(spec.key, e.target.value)}
+                  className={`${controlClass} mt-1 resize-y`}
+                />
+              )
             ) : spec.kind === "choice" ? (
               <select
                 id={id}

--- a/src/components/SubmitForm.tsx
+++ b/src/components/SubmitForm.tsx
@@ -17,8 +17,6 @@ import { DuplicateHint } from "@/components/DuplicateHint";
 import { EntryFields } from "@/components/EntryFields";
 import { useViewer } from "@/components/ViewerProvider";
 
-
-
 export function SubmitForm() {
   const { signedIn, loaded, isAdmin } = useViewer();
   const [values, setValues] = useState<SubmissionValues>(emptySubmission);
@@ -210,6 +208,7 @@ export function SubmitForm() {
               setValues((v) => ({ ...v, [key]: value }) as SubmissionValues)
             }
             idPrefix="submit"
+            texPreview
             // Under the title only. Duplicates are the commonest avoidable
             // rejection, and the title is the field that can predict one.
             renderAfter={(key) =>

--- a/src/components/TeX.tsx
+++ b/src/components/TeX.tsx
@@ -1,6 +1,6 @@
 import katex from "katex";
-import { linkifyEscaped } from "@/lib/linkify";
-import { TEX_TOKENS, isDisplayMath, isInlineMath, unescapeDollars } from "@/lib/tex-tokens";
+import { renderTexToHtml } from "@/lib/tex-render";
+import { unescapeDollars } from "@/lib/tex-tokens";
 
 // Server-rendered math. This is a server component, so KaTeX runs at build time
 // and the rendered markup ships in the static HTML - no client JS, no flash of
@@ -9,12 +9,6 @@ import { TEX_TOKENS, isDisplayMath, isInlineMath, unescapeDollars } from "@/lib/
 
 function render(tex: string, display: boolean): string {
   return katex.renderToString(tex, { throwOnError: false, displayMode: display });
-}
-
-// Non-math segments become raw HTML too, so they must be escaped here - React
-// is no longer doing it for us.
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 /// Renders `$inline$` / `$$display$$` math to an HTML string, escaping
@@ -28,28 +22,7 @@ function escapeHtml(s: string): string {
 /// inside a stretched <a>, and an anchor nested in an anchor is invalid HTML.
 /// Prose fields ask for it; titles do not.
 export function texToHtml(children: string, opts?: { linkify?: boolean }): string {
-  const parts = children.split(TEX_TOKENS);
-  const isDisplay = isDisplayMath;
-  return parts
-    .map((part, i) => {
-      if (isDisplay(part)) return render(part.slice(2, -2), true);
-      if (isInlineMath(part)) return render(part.slice(1, -1), false);
-      // Newlines are meaningful here, and used to vanish: HTML collapses them,
-      // so a statement written as a list rendered as one run-on paragraph.
-      // Thirteen statements, ten AI-role notes and eight verification notes
-      // were affected. A blank line yields two breaks, which reads as a
-      // paragraph gap without nesting a <p> inside the <p> these render in.
-      //
-      // KaTeX display math is already a block, so a newline touching one would
-      // add a second gap - those get dropped rather than doubled.
-      let text = part;
-      if (isDisplay(parts[i - 1] ?? "")) text = text.replace(/^\n/, "");
-      if (isDisplay(parts[i + 1] ?? "")) text = text.replace(/\n$/, "");
-      const escaped = escapeHtml(text);
-      const linked = opts?.linkify ? linkifyEscaped(escaped) : escaped;
-      return unescapeDollars(linked).replace(/\n/g, "<br>");
-    })
-    .join("");
+  return renderTexToHtml(children, render, opts);
 }
 
 export function TeX({ children, linkify }: { children: string; linkify?: boolean }) {

--- a/src/components/TeXPreviewTextarea.tsx
+++ b/src/components/TeXPreviewTextarea.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useDeferredValue, useEffect, useState } from "react";
+import { renderTexToHtml } from "@/lib/tex-render";
+
+export function TeXPreviewTextarea({
+  id,
+  value,
+  onChange,
+  className,
+  label,
+}: {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  className: string;
+  label: string;
+}) {
+  const [activeTab, setActiveTab] = useState<"text" | "preview">("text");
+  const deferredValue = useDeferredValue(value);
+  const [rendered, setRendered] = useState({ source: "", html: "", error: "" });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (activeTab !== "preview" || !deferredValue) return;
+
+    void import("katex")
+      .then(({ default: katex }) => {
+        if (cancelled) return;
+        const next = renderTexToHtml(
+          deferredValue,
+          (tex, display) =>
+            katex.renderToString(tex, {
+              displayMode: display,
+              throwOnError: false,
+              trust: false,
+            }),
+          { linkify: true },
+        );
+        setRendered({ source: deferredValue, html: next, error: "" });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRendered({
+            source: deferredValue,
+            html: "",
+            error: "The preview could not be rendered.",
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, deferredValue]);
+
+  const current = deferredValue !== "" && rendered.source === deferredValue;
+  const html = current ? rendered.html : "";
+  const error = current ? rendered.error : "";
+  const loading = deferredValue !== "" && !current;
+
+  return (
+    <div className="mt-1">
+      <div className="mb-1 flex gap-1" role="tablist" aria-label={`${label} view`}>
+        <button
+          type="button"
+          role="tab"
+          id={`${id}-text-tab`}
+          aria-controls={`${id}-text-panel`}
+          aria-selected={activeTab === "text"}
+          onClick={() => setActiveTab("text")}
+          className={`rounded px-2.5 py-1 text-xs transition-colors ${
+            activeTab === "text"
+              ? "bg-[var(--ink)] text-[var(--paper)]"
+              : "text-[var(--ink-muted)] hover:bg-[var(--paper-raised)] hover:text-[var(--ink)]"
+          }`}
+        >
+          Text
+        </button>
+        <button
+          type="button"
+          role="tab"
+          id={`${id}-preview-tab`}
+          aria-controls={`${id}-preview-panel`}
+          aria-selected={activeTab === "preview"}
+          onClick={() => setActiveTab("preview")}
+          className={`rounded px-2.5 py-1 text-xs transition-colors ${
+            activeTab === "preview"
+              ? "bg-[var(--ink)] text-[var(--paper)]"
+              : "text-[var(--ink-muted)] hover:bg-[var(--paper-raised)] hover:text-[var(--ink)]"
+          }`}
+        >
+          LaTeX preview
+        </button>
+      </div>
+
+      {activeTab === "text" ? (
+        <div
+          role="tabpanel"
+          id={`${id}-text-panel`}
+          aria-labelledby={`${id}-text-tab`}
+        >
+          <textarea
+            id={id}
+            value={value}
+            rows={7}
+            onChange={(event) => onChange(event.target.value)}
+            className={`${className} min-h-40 resize-y font-mono`}
+            aria-describedby={`${id}-preview-help`}
+          />
+        </div>
+      ) : (
+        <div
+          role="tabpanel"
+          id={`${id}-preview-panel`}
+          aria-labelledby={`${id}-preview-tab`}
+          className="math-prose min-h-40 rounded border border-[var(--hairline)] bg-[var(--paper-raised)] px-3 py-2 text-sm leading-relaxed text-[var(--ink-secondary)]"
+          aria-busy={loading}
+        >
+          {error ? (
+            <p className="text-[var(--status-critical)]" role="status">
+              {error}
+            </p>
+          ) : html ? (
+            <span dangerouslySetInnerHTML={{ __html: html }} />
+          ) : (
+            <p className="text-[var(--ink-muted)]">
+              Nothing to preview yet. Plain text is fine; use $...$ for inline
+              math and $$...$$ for display math.
+            </p>
+          )}
+        </div>
+      )}
+
+      <p id={`${id}-preview-help`} className="sr-only">
+        Select the LaTeX preview tab to see a read-only rendering.
+      </p>
+    </div>
+  );
+}

--- a/src/components/TeXPreviewTextarea.tsx
+++ b/src/components/TeXPreviewTextarea.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useDeferredValue, useEffect, useState } from "react";
+import {
+  useDeferredValue,
+  useEffect,
+  useState,
+  type ChangeEvent,
+  type FocusEventHandler,
+  type KeyboardEventHandler,
+  type Ref,
+} from "react";
 import { renderTexToHtml } from "@/lib/tex-render";
 
 export function TeXPreviewTextarea({
@@ -9,12 +17,28 @@ export function TeXPreviewTextarea({
   onChange,
   className,
   label,
+  rows = 7,
+  heightClass = "min-h-40",
+  monospace = false,
+  textareaRef,
+  placeholder,
+  autoFocus,
+  onBlur,
+  onKeyDown,
 }: {
   id: string;
   value: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, event: ChangeEvent<HTMLTextAreaElement>) => void;
   className: string;
   label: string;
+  rows?: number;
+  heightClass?: string;
+  monospace?: boolean;
+  textareaRef?: Ref<HTMLTextAreaElement>;
+  placeholder?: string;
+  autoFocus?: boolean;
+  onBlur?: FocusEventHandler<HTMLTextAreaElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>;
 }) {
   const [activeTab, setActiveTab] = useState<"text" | "preview">("text");
   const deferredValue = useDeferredValue(value);
@@ -102,12 +126,18 @@ export function TeXPreviewTextarea({
           aria-labelledby={`${id}-text-tab`}
         >
           <textarea
+            ref={textareaRef}
             id={id}
             value={value}
-            rows={7}
-            onChange={(event) => onChange(event.target.value)}
-            className={`${className} min-h-40 resize-y font-mono`}
+            rows={rows}
+            onChange={(event) => onChange(event.target.value, event)}
+            className={`${className} ${heightClass} resize-y ${monospace ? "font-mono" : ""}`}
             aria-describedby={`${id}-preview-help`}
+            aria-label={label}
+            placeholder={placeholder}
+            autoFocus={autoFocus}
+            onBlur={onBlur}
+            onKeyDown={onKeyDown}
           />
         </div>
       ) : (
@@ -115,7 +145,7 @@ export function TeXPreviewTextarea({
           role="tabpanel"
           id={`${id}-preview-panel`}
           aria-labelledby={`${id}-preview-tab`}
-          className="math-prose min-h-40 rounded border border-[var(--hairline)] bg-[var(--paper-raised)] px-3 py-2 text-sm leading-relaxed text-[var(--ink-secondary)]"
+          className={`math-prose ${heightClass} rounded border border-[var(--hairline)] bg-[var(--paper-raised)] px-3 py-2 text-sm leading-relaxed text-[var(--ink-secondary)]`}
           aria-busy={loading}
         >
           {error ? (

--- a/src/lib/tex-render.ts
+++ b/src/lib/tex-render.ts
@@ -1,0 +1,37 @@
+import { linkifyEscaped } from "@/lib/linkify";
+import { TEX_TOKENS, isDisplayMath, isInlineMath, unescapeDollars } from "@/lib/tex-tokens";
+
+export type MathRenderer = (tex: string, display: boolean) => string;
+
+// Non-math segments become raw HTML too, so they must be escaped here - React
+// is no longer doing it for us.
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/// The shared prose-and-math pipeline. The published renderer supplies the
+/// server KaTeX instance; the submission preview supplies a lazily loaded
+/// browser instance. Keeping the splitting and escaping here means the preview
+/// cannot quietly accept syntax that the published entry renders differently.
+export function renderTexToHtml(
+  children: string,
+  renderMath: MathRenderer,
+  opts?: { linkify?: boolean },
+): string {
+  const parts = children.split(TEX_TOKENS);
+  return parts
+    .map((part, i) => {
+      if (isDisplayMath(part)) return renderMath(part.slice(2, -2), true);
+      if (isInlineMath(part)) return renderMath(part.slice(1, -1), false);
+
+      // Display math is already a block, so discard a newline touching it
+      // rather than rendering a duplicate gap.
+      let text = part;
+      if (isDisplayMath(parts[i - 1] ?? "")) text = text.replace(/^\n/, "");
+      if (isDisplayMath(parts[i + 1] ?? "")) text = text.replace(/\n$/, "");
+      const escaped = escapeHtml(text);
+      const linked = opts?.linkify ? linkifyEscaped(escaped) : escaped;
+      return unescapeDollars(linked).replace(/\n/g, "<br>");
+    })
+    .join("");
+}


### PR DESCRIPTION
## Goal

Let contributors verify copied LaTeX before submitting or posting it, without turning VibeMathed into a heavy LaTeX editor. Plain text remains fully supported, editing remains the default view, and rendering is an explicit read-only check.

## What changed

- Adds a reusable `TeXPreviewTextarea` with two tabs: **Text** (default) and **LaTeX preview** (read-only).
- Enables the control for every textarea on the submission form.
- Reuses the same control for new comments, replies, and comment edits.
- Lazy-loads browser-side KaTeX only when someone opens a preview.
- Extracts the prose/math splitting and escaping into a shared renderer so browser previews and published server-rendered content use the same `$inline$` / `$$display$$` rules.
- Preserves existing textarea behavior, including character counts, draft storage, comment emoji insertion, autofocus, resizing, and Ctrl/Cmd+Enter submission.
- Keeps KaTeX `trust: false` for previewed user input.

## Impacted areas

- Submission form textarea UI
- Comment, reply, and comment-edit composers
- Shared TeX tokenization, escaping, and HTML rendering path
- Client bundle behavior: KaTeX is now available as an on-demand chunk on authoring surfaces, while normal reader rendering stays server-side

Published data and database schema are unchanged.

## Screenshots

Submission form:

<img width="761" height="410" alt="Screenshot 2026-09-03 at 10 48 04 AM" src="https://github.com/user-attachments/assets/742ce4e9-75b9-4026-b54a-4f43a487e4e6" />
<img width="727" height="353" alt="Screenshot 2026-09-03 at 10 47 52 AM" src="https://github.com/user-attachments/assets/5649d7bf-820d-4cc8-9b98-72875e469195" />

Comment section:

<img width="769" height="234" alt="Screenshot 2026-09-03 at 10 48 19 AM" src="https://github.com/user-attachments/assets/8bf19fbf-c8f7-4e38-abd4-dd5945f9b212" />
<img width="743" height="416" alt="Screenshot 2026-09-03 at 10 48 24 AM" src="https://github.com/user-attachments/assets/805035d1-c16c-4242-99f2-a067e61f1608" />

## Validation

- `npm run typecheck`
- `npm test` — 55 tests passed
- `npm run lint` — passes with three pre-existing warnings
- `npm run build -- --webpack`
