### PR TITLE
Promote main to production: catch up the two commits before the branch flip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,11 +33,26 @@ are the authority, not memory.
 For anything non-trivial, open an issue first and say what you intend to
 change. A short conversation is cheaper than a rejected pull request.
 
+## Which branch
+
+**Branch from `main` and open your pull request against `main`.** That is
+where everything lands first, and it is always the furthest ahead, so your
+branch never carries anyone else's history and your diff is only your own
+commits.
+
+`production` is what vibemathed.com serves. Code reaches it by a deliberate
+promotion from `main`, never by momentum. You will not normally touch it.
+
+Do not target `staging`. It is being retired; anything opened against it
+should be retargeted to `main`.
+[`docs/branch-flow.md`](docs/branch-flow.md) explains the reasoning and lists
+the migration steps still outstanding.
+
 ## Checks
 
 CI runs `npm run lint`, `npm run typecheck` and `npm test` on every pull
-request, and `main` will not merge without them. Run all three locally before
-pushing.
+request, and neither `main` nor `production` will merge without them. Run all
+three locally before pushing.
 
 The tests are unit tests for the pure modules under `src/lib` (and the pure
 functions that live beside components, like `texToHtml`): `src/**/*.test.ts`,

--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ Catalog contributions - new entries, corrections, challenges to a claim - go
 through the site rather than through git, because the catalog lives in a
 database: see [vibemathed.com/contributing](https://vibemathed.com/contributing).
 
-For code, see [CONTRIBUTING.md](CONTRIBUTING.md). Pull requests go to `staging`
-first, which runs at its own URL against its own database
-([`docs/staging.md`](docs/staging.md)), and are promoted to `main` from there.
-`main` requires a green CI run and one approval.
+For code, see [CONTRIBUTING.md](CONTRIBUTING.md). **Pull requests go to
+`main`**, which is where everything lands first; `production` is what
+vibemathed.com serves, and reaching it is a deliberate promotion. Both require
+a green CI run and one approval. [`docs/branch-flow.md`](docs/branch-flow.md)
+explains why, and lists the two migration steps still outstanding - until they
+are done, `main` is still the branch that deploys to production.
 
 ## License
 

--- a/docs/branch-flow.md
+++ b/docs/branch-flow.md
@@ -1,0 +1,101 @@
+# Branch flow
+
+**Status: agreed and half-migrated. The last two steps need the operator's
+hands; until they are done, `main` is still the production branch and the
+"how it works" section below describes the target, not the present.** The
+"Where it stands" section at the bottom says exactly which is which.
+
+## The problem this fixes
+
+The old flow was one-directional on paper - branch → `staging` → `main` - and
+it broke in practice, because the person with commit rights pushed straight to
+`main`. Twelve times on 2 September alone. `staging` starved, drifted 42
+commits behind, and every pull request opened against it arrived carrying
+someone else's history:
+
+- **PR #13** conflicted in `docs/staging.md`, a file the contributor never
+  touched.
+- **PR #14** reported a typecheck error against `src/app/queue/page.js`, a
+  route that exists on `main` and not on `staging`, from a stale `.next`.
+- Both PRs showed 25 commits, 23 of which were ours.
+
+The topology was not the problem. The problem is that the branch contributors
+were told to target was not the branch that was furthest ahead, and any
+arrangement with that property drifts. Proposed by Eugene Gilburg, accepted
+3 September 2026.
+
+## How it works
+
+```
+feature branch ──PR──► main ──PR──► production
+                        │              │
+                   staging env     vibemathed.com
+                   (own database)  (production database)
+```
+
+- **`main` is where everything lands first**, and it deploys to the staging
+  environment. Contributors branch from it and open pull requests against it.
+  A push straight to `main` is now harmless: it reaches staging, gets clicked
+  through, and goes no further on its own.
+- **`production` is what the site serves.** Reaching it is a deliberate act -
+  a pull request from `main`, or a promotion workflow. Nothing arrives there
+  by momentum.
+- **Hotfixes** may go straight to `production` and must then be brought back
+  to `main`, or the next promotion silently reverts them.
+
+Both branches require a green `checks` run and one approving review.
+`enforce_admins` is false on both, which is the operator's escape hatch and
+should stay a hatch rather than a habit.
+
+### Why the site keeps a long-lived staging branch at all
+
+Because OAuth redirect URIs are registered in advance. Vercel gives a
+long-lived branch a stable alias; a per-PR preview gets a new URL on every
+deploy, and no OAuth provider will accept a wildcard. So a preview deployment
+cannot exercise anything behind sign-in, which is most of what is worth
+clicking through. That is why "delete staging, use previews" is not the
+answer, and why the staging environment moves to `main` rather than
+disappearing.
+
+### What this costs
+
+Production deploys become explicit. For a site that publishes a public record
+of other people's mathematics, that is the right side to err on: on
+2 September a change passed lint, typecheck and 55 tests and still failed the
+production build, and vibemathed.com served a stale build for twenty minutes.
+Under this flow that lands in staging and nobody outside notices.
+
+The cost is only acceptable if promotion is one action. If it becomes a
+ceremony it will be bypassed within a week.
+
+## Where it stands
+
+Done:
+
+- [x] `production` branch created at `51baf67`, the then-current `main`.
+- [x] `production` protected: `checks` required and strict, one approving
+      review, stale reviews dismissed, no force pushes, no deletions.
+- [x] Open pull requests retargeted from `staging` to `main`.
+
+Remaining, and both need the operator:
+
+- [ ] **Move the staging environment from the `staging` branch to `main`.**
+      Seven branch-scoped variables in Vercel are bound to the branch *name*
+      `staging`: `DATABASE_URL`, `AUTH_SECRET`, `AUTH_URL`, and the Google and
+      GitHub client ids and secrets. They must be rebound to `main`, and
+      `AUTH_URL` must change from
+      `https://vibemathed-git-staging-rasmus-projects-f85c1805.vercel.app` to
+      `https://vibemathed-git-main-rasmus-projects-f85c1805.vercel.app`.
+- [ ] **Register that URL as a redirect URI in the Google and GitHub OAuth
+      applications.** This is the step nobody but the operator can do, and
+      skipping it breaks sign-in on staging without breaking anything else,
+      which is a confusing failure. Do it before the rebind, not after.
+- [ ] **Change the Vercel project's production branch from `main` to
+      `production`.** Safe at the moment both point at the same commit; do it
+      then, and confirm vibemathed.com is unchanged before pushing anything
+      new to `main`.
+- [ ] Retire the `staging` branch once its environment has moved. Delete it
+      rather than leaving a third long-lived branch to drift.
+
+Until those are done, `main` is still the production branch, and a push to
+`main` still deploys to vibemathed.com.

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,3 +1,11 @@
+> **Being superseded.** The staging *environment* stays; the `staging`
+> *branch* is going away. Under the flow agreed on 3 September 2026 the
+> staging environment hangs off `main` instead, and `production` becomes the
+> branch that serves vibemathed.com. See
+> [`branch-flow.md`](branch-flow.md) for the reasoning and for the two
+> migration steps still outstanding. Everything below still describes how the
+> environment behaves; only the branch it is bound to changes.
+
 # The staging environment
 
 Staging is a full copy of the site running the `staging` branch, at a fixed

--- a/src/lib/submission.ts
+++ b/src/lib/submission.ts
@@ -162,11 +162,12 @@ export function emptySubmission(): SubmissionValues {
 export { MESSAGE_MAX as REVIEW_MESSAGE_MAX } from "@/lib/messages";
 
 export const SUBMISSION_WINDOW_MS = 24 * 60 * 60 * 1000;
-/// Raised from 3 to 5. Three was set when the queue was the bottleneck; the
+/// Raised 3 -> 5 -> 10. Three was set when the queue was the bottleneck; the
 /// people actually hitting it turned out to be the regulars sending several
 /// good entries in a sitting, which is the traffic this site wants, not the
-/// flooding the throttle exists to stop.
-export const SUBMISSIONS_PER_WINDOW = 5;
+/// flooding the throttle exists to stop. Ten because the most prolific
+/// submitter reached five in a day with a 4% rejection rate.
+export const SUBMISSIONS_PER_WINDOW = 10;
 
 /// URL-safe id derived from the entry name. Uniqueness is enforced by the
 /// caller against the database.


### PR DESCRIPTION
First use of the promotion path from `docs/branch-flow.md`, and a prerequisite
for the last migration step rather than a routine promotion.

## Why now

`production` was cut at `51baf67` this afternoon and `main` moved on twice
within ten minutes:

| | |
|---|---|
| `production` | `51baf67` |
| `main` | `3ee2e37` |
| in between | `e384575` Adopt the one-way branch flow |
| | `3ee2e37` Raise max daily submission count to 10 (#14) |

vibemathed.com is currently served from `main`, and the live deployment was
built at 14:40, five minutes after `3ee2e37` landed. So the site is already
serving both of those commits.

`docs/branch-flow.md` says to flip the Vercel production branch "at the moment
both point at the same commit". That stopped being true at 14:30. Flipping now
would point production at `51baf67` and roll the live site back two commits,
taking the raised submission limit with it.

This is a fast-forward: `51baf67` is an ancestor of `3ee2e37`, so nothing is
merged and no history is rewritten.

## After this merges

1. Add the `main` branch alias to the two staging OAuth apps as a redirect URI.
2. Rebind the seven branch-scoped Vercel variables from `staging` to `main`.
3. Flip the Vercel production branch from `main` to `production`.
4. Confirm vibemathed.com is unchanged, then delete `staging`.

Only after step 3 does a push to `main` stop reaching the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JRt3ntfbTUxZKXDjd1wGu