### PR TITLE
Take Members out of the header

### DIFF
--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -18,7 +18,12 @@ const LINKS = [
   // Frontiers are a different shape from entries (a quantity with a history,
   // not a result), so they get their own section rather than a filter chip.
   { href: "/frontiers", label: "Frontiers" },
-  { href: "/users", label: "Members" },
+  // Members is deliberately not here. The directory exists for people already
+  // on the site and is reached from the footer, from beside Latest activity
+  // and from the stat band - the places where wanting to know who else is
+  // here actually occurs to someone. A header slot would give a page most
+  // readers never need the same weight as the record itself. It was in the
+  // header for one day (PR #18) and came out again on 5 September 2026.
   { href: "/stats", label: "Stats" },
   { href: "/methodology", label: "Methodology" },
   { href: "/about", label: "About" },
@@ -28,10 +33,6 @@ function isActive(href: string, path: string): boolean {
   if (href === "/") {
     // Entry pages belong to the Entries section.
     return path === "/" || path.startsWith("/problem");
-  }
-  if (href === "/users") {
-    // Individual profiles belong to the Members section.
-    return path === "/users" || path.startsWith("/user/");
   }
   return path === href || path.startsWith(`${href}/`);
 }


### PR DESCRIPTION
Restores the member directory's original placement.

`/users` was added on 20 August with a written reason for **not** being in the header: the directory is for people already on the site, and it is reached from the footer, from beside Latest activity and from the stat band, which is where wanting to know who else is here actually occurs to someone. A fifth top-level item "would crowd the phone bar for a page most readers never need". PR #18's navigation reorganisation put it in the header anyway; review did not catch that it reversed a decision with a reason attached.

This takes the header slot away again and nothing else. The page, its two privacy opt-outs and the three other links to it are untouched. The `isActive` special case for `/user/` goes with it since nothing in the header claims profiles any more.

**Verify:** header on any page reads Entries · Stats · Methodology · About (plus Frontiers once #22 lands); footer still links Members; `/users` still loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GhhXvqCBAoaPpswAsS1mu