### PR TITLE
Raise the per-entry link cap from 8 to 16

### DIFF
--- a/src/lib/editable.ts
+++ b/src/lib/editable.ts
@@ -408,7 +408,16 @@ export function toEditableValues(source: Pick<MathProblem, EditableKey>): Editab
   return out;
 }
 
-export const MAX_LINKS = 8;
+/// Extra links per entry, beyond the primary source. Was 8; raised on
+/// 5 September 2026 when the K8-e release arrived carrying six links (proof,
+/// checker, problem record, review archive, companion, PR) and the two
+/// Astra disproofs each needed the compared statement, the development, the
+/// Formal Conjectures source and the evaluation repository on top of the
+/// announcement. Eight was low for exactly the well-documented entries the
+/// site wants more of. Sixteen keeps a cap, since a link list is curated
+/// evidence rather than a bibliography, and the editor still adds rows one at
+/// a time.
+export const MAX_LINKS = 16;
 
 /// Serializes link rows for transport through the string-keyed form values.
 export function encodeLinks(links: LinkRef[]): string {


### PR DESCRIPTION
The K8-e release carries six links and the two Astra disproofs each needed five. Eight was low for exactly the well-documented entries the site wants more of, and the curator hit "At most 8 extra links" editing one. Sixteen keeps a cap; `MAX_RELATIONS` stays at 8.

One constant, used by the editor's add-row guard and by `parseLinks` on both the submit and update actions, so client and server move together.

**Verify:** open an entry with 8 links in the editor; the add-row button is back and saving a ninth succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019E3z8ia1aR6UiQC7yeLrhD