### PR TITLE
Increase submission limit, fix bug

### DIFF
--- a/src/app/actions/submit-problem.ts
+++ b/src/app/actions/submit-problem.ts
@@ -12,7 +12,7 @@ import { isHttpUrl, isValidSolveDate, parseLinks } from "@/lib/editable";
 import {
   SUBMISSION_FIELDS,
   SUBMISSION_WINDOW_MS,
-  SUBMISSIONS_PER_WINDOW,
+  submissionLimit,
   slugify,
   type SubmissionValues,
 } from "@/lib/submission";
@@ -38,14 +38,19 @@ export async function submitProblem(values: SubmissionValues): Promise<SubmitRes
   // A few submissions per person per day, so a burst cannot flood the queue.
   // Admins bypass it.
   if (!admin) {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { verified: true },
+    });
+    const limit = submissionLimit(user?.verified ?? false);
     const since = new Date(Date.now() - SUBMISSION_WINDOW_MS);
     const recent = await prisma.problem.count({
       where: { submittedById: userId, createdAt: { gte: since } },
     });
-    if (recent >= SUBMISSIONS_PER_WINDOW) {
+    if (recent >= limit) {
       return {
         ok: false,
-        error: `You can submit up to ${SUBMISSIONS_PER_WINDOW} entries per rolling 24 hours. Try again later.`,
+        error: `You can submit up to ${limit} entries per rolling 24 hours. Try again later.`,
       };
     }
   }
@@ -176,12 +181,19 @@ export async function submitProblem(values: SubmissionValues): Promise<SubmitRes
   } as unknown as Prisma.ProblemUncheckedCreateInput;
 
   try {
-    const created = await prisma.problem.create({
-      data: createInput,
-      select: { id: true },
-    });
-    await prisma.problemActivity.create({
-      data: { problemId: created.id, userId, userName, type: "submitted" },
+    // Keep the entry and its audit event atomic: a failed event must not
+    // leave a saved entry behind while telling the submitter to retry.
+    await prisma.$transaction(async (tx) => {
+      const created = await tx.problem.create({
+        data: createInput,
+        select: { id: true },
+      });
+      await tx.problemActivity.create({
+        data: { problemId: created.id, userId, userName, type: "submitted" },
+        // No activity fields are needed. Avoid returning unrelated columns
+        // that may not yet exist in databases awaiting the frontier schema.
+        select: { id: true },
+      });
     });
   } catch (error) {
     console.error("submitProblem failed", error);

--- a/src/components/SubmitForm.tsx
+++ b/src/components/SubmitForm.tsx
@@ -8,7 +8,7 @@ import {
   SUBMISSION_DRAFT_KEY,
   SUBMISSION_FIELDS,
   SUBMISSION_GROUPS,
-  SUBMISSIONS_PER_WINDOW,
+  submissionLimit,
   emptySubmission,
   type SubmissionValues,
 } from "@/lib/submission";
@@ -18,7 +18,7 @@ import { EntryFields } from "@/components/EntryFields";
 import { useViewer } from "@/components/ViewerProvider";
 
 export function SubmitForm() {
-  const { signedIn, loaded, isAdmin } = useViewer();
+  const { signedIn, loaded, isAdmin, verified } = useViewer();
   const [values, setValues] = useState<SubmissionValues>(emptySubmission);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -161,7 +161,7 @@ export function SubmitForm() {
               "three" for a while after the limit became five, which is the
               kind of small lie that costs a submission. */}
           {!isAdmin &&
-            ` You can submit up to ${SUBMISSIONS_PER_WINDOW} entries per day.`}{" "}
+            ` You can submit up to ${submissionLimit(verified)} entries per rolling 24 hours.`}{" "}
           Full
           criteria in the{" "}
           <Link

--- a/src/lib/submission.ts
+++ b/src/lib/submission.ts
@@ -152,8 +152,8 @@ export function emptySubmission(): SubmissionValues {
   return out;
 }
 
-/// Submission throttle: up to SUBMISSIONS_PER_WINDOW entries per person per
-/// rolling 24 hours. Admins are exempt. Generous enough for a productive
+/// Submission throttle: 10 entries for unverified users, 25 for verified users
+/// per rolling 24 hours. Admins are exempt. Generous enough for a productive
 /// contributor with several results (it happens), still a cap on spam - and
 /// note that curator-entered rows credited to an account count against its
 /// quota too, since the check is by submitter id.
@@ -162,12 +162,12 @@ export function emptySubmission(): SubmissionValues {
 export { MESSAGE_MAX as REVIEW_MESSAGE_MAX } from "@/lib/messages";
 
 export const SUBMISSION_WINDOW_MS = 24 * 60 * 60 * 1000;
-/// Raised 3 -> 5 -> 10. Three was set when the queue was the bottleneck; the
-/// people actually hitting it turned out to be the regulars sending several
-/// good entries in a sitting, which is the traffic this site wants, not the
-/// flooding the throttle exists to stop. Ten because the most prolific
-/// submitter reached five in a day with a 4% rejection rate.
 export const SUBMISSIONS_PER_WINDOW = 10;
+export const VERIFIED_SUBMISSIONS_PER_WINDOW = 25;
+
+export function submissionLimit(verified: boolean): number {
+  return verified ? VERIFIED_SUBMISSIONS_PER_WINDOW : SUBMISSIONS_PER_WINDOW;
+}
 
 /// URL-safe id derived from the entry name. Uniqueness is enforced by the
 /// caller against the database.


### PR DESCRIPTION
## What this changes

Increased verified user limit to 25

## Why

Ran out of submission limit

## How to check it

Hard to check because need 25 submissions, but can manually change in code to a small number.

## Checklist

- [ ] Opened against `staging` (not `main`) - see [CONTRIBUTING.md](../CONTRIBUTING.md) <- opened against main per new code flow, should fix the github rules
- [x] `npm run lint` and `npm run typecheck` pass <- should also add npm test or make a command which runs all at once
- [x] Comments explaining *why* are updated where the reasoning changed
- [x] No catalog content edited by hand - entries live in the database, not in git
- [x] Any script that writes to a database defaults to a dry run and needs `--apply`

<!-- Not a checklist item, but worth saying if it applies: if this changes
     anything a comment currently justifies, and you disagree with that
     comment's reasoning, say so here rather than deleting it quietly. -->
