### PR TITLE
Entries list: sort by last change

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,11 @@ import {
   getUserCount,
   getVerifiedCount,
 } from "@/lib/data";
-import { SETTINGS_COOKIE, readSettingsCookie, sortValue } from "@/lib/list-settings";
+import {
+  SETTINGS_COOKIE,
+  readSettingsCookie,
+  sortValue,
+} from "@/lib/list-settings";
 import type { CardEntry } from "@/lib/problems";
 import { SITE_URL } from "@/lib/site";
 import { Highlights } from "@/components/Highlights";
@@ -30,7 +34,10 @@ export const metadata: Metadata = {
 /// cards follow the shell by a server render rather than a round trip.
 async function EntryList() {
   // Cached, so asking again here costs nothing beyond the cache read.
-  const [problems, store] = await Promise.all([getPublishedProblems(), cookies()]);
+  const [problems, store] = await Promise.all([
+    getPublishedProblems(),
+    cookies(),
+  ]);
   const initial = readSettingsCookie(store.get(SETTINGS_COOKIE)?.value);
 
   // Statement math is rendered to HTML here, on the server, so the client
@@ -85,6 +92,7 @@ async function EntryList() {
     commentCount: p.commentCount,
     submittedBy: p.submittedBy,
     addedAt: p.addedAt,
+    changedAt: p.changedAt,
     sourceUrl: p.sourceUrl,
     sourceName: p.sourceName,
     links: p.links ?? [],
@@ -187,7 +195,12 @@ export default async function Home() {
         className="grid grid-cols-2 gap-2.5 lg:grid-cols-6"
         aria-label="Overview"
       >
-        <StatBand problems={problems} users={users} pending={pending} verified={verified} />
+        <StatBand
+          problems={problems}
+          users={users}
+          pending={pending}
+          verified={verified}
+        />
         <RecentActivity activity={activity} />
         {/* Five rows, matching the activity feed: the highlight cards then
             fill the column height the feed forces with real content instead

--- a/src/components/ProblemCards.tsx
+++ b/src/components/ProblemCards.tsx
@@ -68,18 +68,18 @@ import { InfoTip, StarNote } from "@/components/Tooltip";
 import { VoteButtons } from "@/components/VoteButtons";
 import { TeX, deTeX } from "@/components/TeX";
 
-
 // The clock for period cutoffs, fixed at module load: render purity wants a
 // stable now, and a cutoff drifting by the age of the tab is nothing against
 // 7/30-day windows.
 const LOADED_AT = Date.now();
 
-
 /// Compact page list: first, last, current and neighbours, with gaps elsewhere.
 function pageWindow(current: number, total: number): (number | "gap")[] {
   if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
   const wanted = new Set([1, total, current, current - 1, current + 1]);
-  const nums = [...wanted].filter((p) => p >= 1 && p <= total).sort((a, b) => a - b);
+  const nums = [...wanted]
+    .filter((p) => p >= 1 && p <= total)
+    .sort((a, b) => a - b);
   const out: (number | "gap")[] = [];
   let prev = 0;
   for (const p of nums) {
@@ -112,7 +112,13 @@ function Chevron({ dir }: { dir: "left" | "right" }) {
 /// whitespace-nowrap: values like a six-model credit line are wider than a
 /// phone-sized card, so a fact must be able to wrap internally rather than
 /// overflow the card.
-function Fact({ label, children }: { label: string; children: React.ReactNode }) {
+function Fact({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
   return (
     <span>
       <span className="text-[var(--ink-muted)]">{label} </span>
@@ -131,18 +137,38 @@ function formatAddedDate(iso: string): string {
 }
 
 const MONTHS_SHORT = [
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
 ];
 
-function ProblemCard({ p, statementHtml }: { p: CardEntry; statementHtml: string | null }) {
+function ProblemCard({
+  p,
+  statementHtml,
+}: {
+  p: CardEntry;
+  statementHtml: string | null;
+}) {
   const st = SOLVE_TYPE[p.solveType];
   // The primary source counts as a link. For 265 of the entries it IS the
   // paper, so leaving it out would have shown a paper icon only on the
   // minority that happen to carry a second copy as an extra link. It has no
   // stored kind of its own, so it is classified from its URL and name.
   const linkIcons = topLinkKinds([
-    { url: p.sourceUrl, label: p.sourceName, kind: inferLinkKind(p.sourceUrl, p.sourceName) },
+    {
+      url: p.sourceUrl,
+      label: p.sourceName,
+      kind: inferLinkKind(p.sourceUrl, p.sourceName),
+    },
     ...p.links,
   ]);
   // The trust badge: verification when it says something; the publication
@@ -235,7 +261,11 @@ function ProblemCard({ p, statementHtml }: { p: CardEntry; statementHtml: string
 
         {/* Votes, kept out of the flowing text so they line up down the list */}
         <div className="relative z-10 shrink-0 pt-0.5">
-          <VoteButtons slug={p.slug} upvotes={p.upvotes} downvotes={p.downvotes} />
+          <VoteButtons
+            slug={p.slug}
+            upvotes={p.upvotes}
+            downvotes={p.downvotes}
+          />
         </div>
       </div>
 
@@ -253,7 +283,9 @@ function ProblemCard({ p, statementHtml }: { p: CardEntry; statementHtml: string
           // Clamped: at the 200-character cap this is five lines on a phone,
           // which on a card buries the identity line under a caveat. The entry
           // page carries it in full.
-          <p className="mt-0.5 line-clamp-2 text-xs text-[var(--ink-muted)]">({p.resultNote})</p>
+          <p className="mt-0.5 line-clamp-2 text-xs text-[var(--ink-muted)]">
+            ({p.resultNote})
+          </p>
         )}
         {/* Identity line */}
         <p className="mt-1 font-mono text-[11px] text-[var(--ink-muted)]">
@@ -276,27 +308,33 @@ function ProblemCard({ p, statementHtml }: { p: CardEntry; statementHtml: string
             the flex default let that whole fact sit visibly lower than its
             neighbours ("Open 11y*" hung below "Posed by" and "Model"). */}
         <div className="mt-2.5 flex flex-wrap items-baseline gap-x-3 gap-y-1 font-mono text-[11px]">
-            <Fact label="Posed by">
-              {p.posedBy ?? DASH}
-              {p.yearPosed !== null && `, ${p.yearPosed}`}
-            </Fact>
-            <span aria-hidden className="text-[var(--hairline)]">·</span>
-            <Fact label="Open">
-              {age !== null ? `${age}y` : DASH}
-              {p.ageNote && <StarNote text={p.ageNote} />}
-            </Fact>
-            <span aria-hidden className="text-[var(--hairline)]">·</span>
-            <Fact label="Model">
-              {p.model}
-              {p.modelMaker && ` (${p.modelMaker})`}
-            </Fact>
-            <span aria-hidden className="text-[var(--hairline)]">·</span>
-            <Fact label="Solved">{p.solveDate}</Fact>
-          </div>
+          <Fact label="Posed by">
+            {p.posedBy ?? DASH}
+            {p.yearPosed !== null && `, ${p.yearPosed}`}
+          </Fact>
+          <span aria-hidden className="text-[var(--hairline)]">
+            ·
+          </span>
+          <Fact label="Open">
+            {age !== null ? `${age}y` : DASH}
+            {p.ageNote && <StarNote text={p.ageNote} />}
+          </Fact>
+          <span aria-hidden className="text-[var(--hairline)]">
+            ·
+          </span>
+          <Fact label="Model">
+            {p.model}
+            {p.modelMaker && ` (${p.modelMaker})`}
+          </Fact>
+          <span aria-hidden className="text-[var(--hairline)]">
+            ·
+          </span>
+          <Fact label="Solved">{p.solveDate}</Fact>
+        </div>
 
-          {/* Verification + notability + discussion */}
-          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px]">
-            {/* Reserved width so Significance starts at the same x down the
+        {/* Verification + notability + discussion */}
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px]">
+          {/* Reserved width so Significance starts at the same x down the
                 list instead of stepping in and out with the badge text.
                 Measured rather than guessed: the widest badge in common use is
                 "Site-confirmed" at 93px, so 6rem reserves 3px of slack. The
@@ -308,101 +346,103 @@ function ProblemCard({ p, statementHtml }: { p: CardEntry; statementHtml: string
                 measured at 360px, nothing wraps to a second line, so the only
                 thing the breakpoint achieved was leaving every screen under
                 640px ragged. */}
+          <span
+            className="relative z-10 inline-flex items-center gap-1.5 min-w-[6rem]"
+            style={{ color: v.color }}
+            title={p.verificationNote ?? undefined}
+          >
+            <StatusIcon kind={v.icon} color={v.color} />
+            {v.label}
+          </span>
+
+          {/* A documented problem with the claim itself - rare, loud. */}
+          {p.claimIssueNote && (
             <span
-              className="relative z-10 inline-flex items-center gap-1.5 min-w-[6rem]"
-              style={{ color: v.color }}
-              title={p.verificationNote ?? undefined}
+              className="relative z-10 inline-flex items-center gap-1.5 text-[var(--status-critical)]"
+              title={p.claimIssueNote}
             >
-              <StatusIcon kind={v.icon} color={v.color} />
-              {v.label}
+              <StatusIcon kind="alert" color="var(--status-critical)" />
+              Claim issue
             </span>
+          )}
 
-            {/* A documented problem with the claim itself - rare, loud. */}
-            {p.claimIssueNote && (
-              <span
-                className="relative z-10 inline-flex items-center gap-1.5 text-[var(--status-critical)]"
-                title={p.claimIssueNote}
-              >
-                <StatusIcon kind="alert" color="var(--status-critical)" />
-                Claim issue
-              </span>
-            )}
-
-            {/* AI-estimated problem weight; the Wikipedia count moved to the
+          {/* AI-estimated problem weight; the Wikipedia count moved to the
                 entry page as a supporting fact (it was almost always 0 here). */}
-            {p.significance !== null && p.significance !== undefined && (
-              // inline-flex, not a plain span. Its neighbours in this row -
-              // the verification badge and the comment link - are inline-flex
-              // boxes because they carry icons, and a plain inline span sits
-              // 1.83px lower than they do under `items-center`, which centres
-              // boxes rather than text. Measured: matching the box type takes
-              // the skew to exactly 0. It is not a font-metric problem;
-              // forcing both spans to the same font family changes nothing.
-              <span className="relative z-10 inline-flex items-center font-mono text-[var(--ink-muted)]">
-                {/* The metric explanation belongs to the label+value only; the
+          {p.significance !== null && p.significance !== undefined && (
+            // inline-flex, not a plain span. Its neighbours in this row -
+            // the verification badge and the comment link - are inline-flex
+            // boxes because they carry icons, and a plain inline span sits
+            // 1.83px lower than they do under `items-center`, which centres
+            // boxes rather than text. Measured: matching the box type takes
+            // the skew to exactly 0. It is not a font-metric problem;
+            // forcing both spans to the same font family changes nothing.
+            <span className="relative z-10 inline-flex items-center font-mono text-[var(--ink-muted)]">
+              {/* The metric explanation belongs to the label+value only; the
                     star carries the per-entry justification. Nesting the star
                     under the same title showed BOTH bubbles when hovering it. */}
-                <span title={SIGNIFICANCE_HELP}>
-                  Significance{" "}
-                  <span className="text-[var(--ink-secondary)]">{p.significance}</span>
+              <span title={SIGNIFICANCE_HELP}>
+                Significance{" "}
+                <span className="text-[var(--ink-secondary)]">
+                  {p.significance}
                 </span>
-                {p.significanceNote && <StarNote text={p.significanceNote} />}
               </span>
-            )}
+              {p.significanceNote && <StarNote text={p.significanceNote} />}
+            </span>
+          )}
 
-            {/* Straight to the artifact. The question a reader most often has
+          {/* Straight to the artifact. The question a reader most often has
                 about an entry on this page is "is there a paper" or "is there
                 a Lean proof", and answering it used to mean opening the entry
                 and reading a list of free-text labels. These are the entry's
                 own links, typed, so the icon is a promise about what is on the
                 other end. z-10 lifts them above the card's click overlay. */}
-            {linkIcons.length > 0 && (
-              <span className="relative z-10 inline-flex items-center gap-1.5">
-                {linkIcons.map(({ spec, link }) => (
-                  <a
-                    key={spec.value}
-                    href={link.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title={`${spec.label}: ${spec.help}`}
-                    aria-label={spec.label}
-                    className="text-[var(--ink-muted)] transition-colors hover:text-[var(--accent-blue)]"
-                  >
-                    <Icon name={spec.icon as IconName} size={14} />
-                  </a>
-                ))}
-              </span>
-            )}
+          {linkIcons.length > 0 && (
+            <span className="relative z-10 inline-flex items-center gap-1.5">
+              {linkIcons.map(({ spec, link }) => (
+                <a
+                  key={spec.value}
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={`${spec.label}: ${spec.help}`}
+                  aria-label={spec.label}
+                  className="text-[var(--ink-muted)] transition-colors hover:text-[var(--accent-blue)]"
+                >
+                  <Icon name={spec.icon as IconName} size={14} />
+                </a>
+              ))}
+            </span>
+          )}
 
-            {/* Credit where an entry came from a reader - contributors should
+          {/* Credit where an entry came from a reader - contributors should
                 see their name on the front page, not only on the entry page.
                 Links to their profile; z-10 lifts it above the card overlay. */}
-            {p.submittedBy && (
-              // The space is a non-breaking one inside the text, not a `{" "}`
-              // between the label and the link. Flexbox drops a whitespace-only
-              // text node sitting between two flex items, so the words ran
-              // together the moment this span became inline-flex; a trailing
-              // ordinary space would be trimmed at the end of its own flex item
-              // too. `gap-1` would work but at 4px reads tighter than the
-              // natural space in `Fact` label/value pairs on the row above.
-              // The Significance span is unaffected only because its space
-              // lives inside a nested inline span.
-              <span className="relative z-10 inline-flex items-center font-mono text-[var(--ink-muted)]">
-                Submitted by&nbsp;
-                <Link
-                  href={`/user/${encodeURIComponent(p.submittedBy)}`}
-                  className="text-[var(--ink-secondary)] hover:text-[var(--accent-blue)] hover:underline"
-                >
-                  {p.submittedBy}
-                </Link>
-                {/* Only alongside a submitter, never on its own. `addedAt` is
+          {p.submittedBy && (
+            // The space is a non-breaking one inside the text, not a `{" "}`
+            // between the label and the link. Flexbox drops a whitespace-only
+            // text node sitting between two flex items, so the words ran
+            // together the moment this span became inline-flex; a trailing
+            // ordinary space would be trimmed at the end of its own flex item
+            // too. `gap-1` would work but at 4px reads tighter than the
+            // natural space in `Fact` label/value pairs on the row above.
+            // The Significance span is unaffected only because its space
+            // lives inside a nested inline span.
+            <span className="relative z-10 inline-flex items-center font-mono text-[var(--ink-muted)]">
+              Submitted by&nbsp;
+              <Link
+                href={`/user/${encodeURIComponent(p.submittedBy)}`}
+                className="text-[var(--ink-secondary)] hover:text-[var(--accent-blue)] hover:underline"
+              >
+                {p.submittedBy}
+              </Link>
+              {/* Only alongside a submitter, never on its own. `addedAt` is
                     row creation, and the curated baseline was seeded within
                     the same few seconds, so on those entries it records when
                     the database was filled rather than anything about the
                     entry. Beside a pseudonym it means what it looks like. */}
-                &nbsp;on&nbsp;{formatAddedDate(p.addedAt)}
-              </span>
-            )}
+              &nbsp;on&nbsp;{formatAddedDate(p.addedAt)}
+            </span>
+          )}
 
           {p.commentCount > 0 && (
             <Link
@@ -436,10 +476,16 @@ export function ProblemCards({
   const [fieldFilter, setFieldFilter] = useState(initial.fieldFilter);
   const [resultFilter, setResultFilter] = useState(initial.resultFilter);
   const [statusFilter, setStatusFilter] = useState(initial.statusFilter);
-  const [contributionFilter, setContributionFilter] = useState(initial.contributionFilter);
+  const [contributionFilter, setContributionFilter] = useState(
+    initial.contributionFilter,
+  );
   const [modelFilter, setModelFilter] = useState(initial.modelFilter);
-  const [verificationFilter, setVerificationFilter] = useState(initial.verificationFilter);
-  const [publicationFilter, setPublicationFilter] = useState(initial.publicationFilter);
+  const [verificationFilter, setVerificationFilter] = useState(
+    initial.verificationFilter,
+  );
+  const [publicationFilter, setPublicationFilter] = useState(
+    initial.publicationFilter,
+  );
   const [methodFilter, setMethodFilter] = useState(initial.methodFilter);
   const [sourceFilter, setSourceFilter] = useState(initial.sourceFilter);
   const [sortKey, setSortKey] = useState<SortKey>(initial.sortKey);
@@ -456,7 +502,8 @@ export function ProblemCards({
   const groups = useMemo(() => {
     const counts = new Map<FieldGroup, number>();
     for (const p of problems) {
-      if (p.fieldGroup) counts.set(p.fieldGroup, (counts.get(p.fieldGroup) ?? 0) + 1);
+      if (p.fieldGroup)
+        counts.set(p.fieldGroup, (counts.get(p.fieldGroup) ?? 0) + 1);
     }
     return FIELD_GROUPS.filter((g) => counts.has(g))
       .map((g) => ({ group: g, count: counts.get(g)! }))
@@ -475,7 +522,9 @@ export function ProblemCards({
   // appears as soon as a SINGLE classified entry exists: with most of the
   // catalog unclassified (null), filtering on one tier is not a no-op.
   const contributions = useMemo(() => {
-    const present = new Set(problems.map((p) => p.aiContribution).filter(Boolean));
+    const present = new Set(
+      problems.map((p) => p.aiContribution).filter(Boolean),
+    );
     return AI_CONTRIBUTIONS.filter((c) => present.has(c));
   }, [problems]);
 
@@ -596,9 +645,9 @@ export function ProblemCards({
     // all rather than one asserting the defaults, and going back to them
     // removes it again - so the common visitor keeps a bare request and the
     // server keeps serving them the same default order it always did.
-    const isDefault = (Object.keys(DEFAULT_SETTINGS) as (keyof ListSettings)[]).every(
-      (k) => s[k] === DEFAULT_SETTINGS[k],
-    );
+    const isDefault = (
+      Object.keys(DEFAULT_SETTINGS) as (keyof ListSettings)[]
+    ).every((k) => s[k] === DEFAULT_SETTINGS[k]);
     try {
       document.cookie = isDefault
         ? `${SETTINGS_COOKIE}=; path=/; max-age=0; samesite=lax`
@@ -632,17 +681,42 @@ export function ProblemCards({
     // identically, so it is put back purely so the address bar stays legible.
     // Safe to do blindly: no option value contains a comma of its own.
     const qs = q.toString().replace(/%2C/g, ",");
-    window.history.replaceState(null, "", qs ? `?${qs}` : window.location.pathname);
-  }, [restored, fieldFilter, resultFilter, statusFilter, contributionFilter, modelFilter, verificationFilter, publicationFilter, methodFilter, sourceFilter, sortKey, sortDir, period, perPage]);
+    window.history.replaceState(
+      null,
+      "",
+      qs ? `?${qs}` : window.location.pathname,
+    );
+  }, [
+    restored,
+    fieldFilter,
+    resultFilter,
+    statusFilter,
+    contributionFilter,
+    modelFilter,
+    verificationFilter,
+    publicationFilter,
+    methodFilter,
+    sourceFilter,
+    sortKey,
+    sortDir,
+    period,
+    perPage,
+  ]);
 
   // Statements beyond the first default-sort page ship without their rendered
   // HTML; one background fetch fills the map after hydration (see CardEntry).
-  const [lateStatements, setLateStatements] = useState<Record<string, string> | null>(null);
+  const [lateStatements, setLateStatements] = useState<Record<
+    string,
+    string
+  > | null>(null);
   useEffect(() => {
-    if (!problems.some((p) => p.hasStatement && p.statementHtml === null)) return;
+    if (!problems.some((p) => p.hasStatement && p.statementHtml === null))
+      return;
     let alive = true;
     fetch("/api/statements")
-      .then((r) => (r.ok ? (r.json() as Promise<Record<string, string>>) : null))
+      .then((r) =>
+        r.ok ? (r.json() as Promise<Record<string, string>>) : null,
+      )
       .then((map) => {
         if (alive && map) setLateStatements(map);
       })
@@ -659,7 +733,9 @@ export function ProblemCards({
   // the panel never lists an empty category.
   const verifications = useMemo(() => {
     const present = new Set(problems.map((p) => p.verification));
-    return (Object.keys(VERIFICATION) as VerificationStatus[]).filter((v) => present.has(v));
+    return (Object.keys(VERIFICATION) as VerificationStatus[]).filter((v) =>
+      present.has(v),
+    );
   }, [problems]);
 
   // The facet groups the Filters panel offers. Same visibility rules the old
@@ -679,7 +755,10 @@ export function ProblemCards({
           {
             key: "status",
             label: "Status",
-            options: resolutions.map((r) => ({ value: r, label: RESOLUTION[r].label })),
+            options: resolutions.map((r) => ({
+              value: r,
+              label: RESOLUTION[r].label,
+            })),
           },
         ]
       : []),
@@ -707,7 +786,10 @@ export function ProblemCards({
     {
       key: "verification",
       label: "Verification",
-      options: verifications.map((v) => ({ value: v, label: VERIFICATION[v].label })),
+      options: verifications.map((v) => ({
+        value: v,
+        label: VERIFICATION[v].label,
+      })),
     },
     {
       key: "publication",
@@ -774,7 +856,9 @@ export function ProblemCards({
     // in sortValue instead, ranking the WHOLE list by that period's activity.
     const dateFiltering = period !== "all" && !TIME_SENSITIVE.includes(sortKey);
     const cutoff = dateFiltering
-      ? new Date(LOADED_AT - PERIOD_DAYS[period as Exclude<Period, "all">] * 86400000)
+      ? new Date(
+          LOADED_AT - PERIOD_DAYS[period as Exclude<Period, "all">] * 86400000,
+        )
           .toISOString()
           .slice(0, 10)
       : "";
@@ -782,16 +866,21 @@ export function ProblemCards({
     // facet is the one filter that cannot compare values directly, and
     // scanning MODEL_FAMILIES per entry per keystroke is work with no payoff.
     const chosenModels = parseSelection(modelFilter);
-    const modelTests = MODEL_FAMILIES.filter((f) => chosenModels.includes(f.key)).map(
-      (f) => f.test,
-    );
+    const modelTests = MODEL_FAMILIES.filter((f) =>
+      chosenModels.includes(f.key),
+    ).map((f) => f.test);
     return problems.filter((p) => {
       if (dateFiltering) {
         // "Added" scopes by when the entry entered the catalog; every other
         // sort scopes by when the problem was solved. Imprecise solve dates
         // ("2026-07") compare lexically and sit out of week-sized windows,
         // which is the honest reading of a date that vague.
-        const stamp = sortKey === "added" ? p.addedAt.slice(0, 10) : p.solveDate;
+        const stamp =
+          sortKey === "added"
+            ? p.addedAt.slice(0, 10)
+            : sortKey === "changed"
+              ? p.changedAt.slice(0, 10)
+              : p.solveDate;
         if (stamp < cutoff) return false;
       }
       // Options within a facet are alternatives, facets AND with each other -
@@ -804,20 +893,23 @@ export function ProblemCards({
       // The one facet matched by pattern rather than by value: an entry names
       // its systems in free text, and a multi-system entry belongs to every
       // family named on it.
-      if (modelTests.length > 0 && !modelTests.some((t) => t.test(p.model))) return false;
+      if (modelTests.length > 0 && !modelTests.some((t) => t.test(p.model)))
+        return false;
       if (!selectionMatches(verificationFilter, p.verification)) return false;
       if (!selectionMatches(publicationFilter, p.publication)) return false;
       if (!selectionMatches(methodFilter, p.resolutionMethod)) return false;
       // Derived from the URL rather than stored, so it cannot drift from
       // the source it describes. Cheap: one URL parse per entry per pass.
-      if (!selectionMatches(sourceFilter, sourceHostKey(p.sourceUrl))) return false;
+      if (!selectionMatches(sourceFilter, sourceHostKey(p.sourceUrl)))
+        return false;
       if (!q) return true;
       // A pasted link or a bare arXiv id is an identity, not a word: compare
       // it against what the entry's links actually point at, so
       // arxiv.org/pdf/2608.13637v2 finds an entry filed under /abs/ and a
       // Zenodo DOI finds one filed under the record URL. Returns early
       // because a match here is exact and needs no text scoring.
-      if (queryId && entrySourceIds(p.sourceUrl, p.links).includes(queryId)) return true;
+      if (queryId && entrySourceIds(p.sourceUrl, p.links).includes(queryId))
+        return true;
       const haystack = [
         // Both forms: a name carrying math is displayed rendered, so someone
         // searching types what they see ("Lp(L1)"), not the source ("$L_p(L_1)$").
@@ -835,7 +927,21 @@ export function ProblemCards({
         .toLowerCase();
       return haystack.includes(q);
     });
-  }, [problems, query, period, sortKey, fieldFilter, resultFilter, statusFilter, contributionFilter, modelFilter, verificationFilter, publicationFilter, methodFilter, sourceFilter]);
+  }, [
+    problems,
+    query,
+    period,
+    sortKey,
+    fieldFilter,
+    resultFilter,
+    statusFilter,
+    contributionFilter,
+    modelFilter,
+    verificationFilter,
+    publicationFilter,
+    methodFilter,
+    sourceFilter,
+  ]);
 
   const sorted = useMemo(() => {
     const arr = [...filtered];
@@ -934,20 +1040,34 @@ export function ProblemCards({
           Algebra plus Analysis shows both - and "All fields" is how you get
           back to none. */}
       <div className="mb-2.5 flex flex-wrap items-center gap-1.5">
-        <button type="button" onClick={() => { touch(); setFieldFilter("all"); }} className={chip(chosenFields.length === 0)}>
+        <button
+          type="button"
+          onClick={() => {
+            touch();
+            setFieldFilter("all");
+          }}
+          className={chip(chosenFields.length === 0)}
+        >
           All fields
-          <span className="font-mono text-[11px] text-[var(--ink-muted)]">{problems.length}</span>
+          <span className="font-mono text-[11px] text-[var(--ink-muted)]">
+            {problems.length}
+          </span>
         </button>
         {groups.map(({ group, count }) => (
           <button
             key={group}
             type="button"
             aria-pressed={chosenFields.includes(group)}
-            onClick={() => { touch(); setFieldFilter(toggleSelection(fieldFilter, group)); }}
+            onClick={() => {
+              touch();
+              setFieldFilter(toggleSelection(fieldFilter, group));
+            }}
             className={chip(chosenFields.includes(group))}
           >
             {group}
-            <span className="font-mono text-[11px] text-[var(--ink-muted)]">{count}</span>
+            <span className="font-mono text-[11px] text-[var(--ink-muted)]">
+              {count}
+            </span>
           </button>
         ))}
       </div>
@@ -967,7 +1087,11 @@ export function ProblemCards({
             className="h-9 w-full rounded border border-[var(--hairline)] bg-[var(--paper-raised)] pl-8 pr-3 text-sm text-[var(--ink)] transition-colors placeholder:text-[var(--ink-muted)] hover:border-[var(--ink-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-blue)]"
           />
         </span>
-        <FilterPanel facets={facets} values={filterValues} onChange={setFilter} />
+        <FilterPanel
+          facets={facets}
+          values={filterValues}
+          onChange={setFilter}
+        />
       </div>
 
       {/* Active facets stay visible as removable chips while the panel is
@@ -985,7 +1109,9 @@ export function ProblemCards({
                 <button
                   key={`${f.key}:${v}`}
                   type="button"
-                  onClick={() => setFilter(f.key, toggleSelection(filterValues[f.key], v))}
+                  onClick={() =>
+                    setFilter(f.key, toggleSelection(filterValues[f.key], v))
+                  }
                   aria-label={`Remove filter: ${label}`}
                   className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-[var(--accent-blue)] bg-[color-mix(in_srgb,var(--accent-blue)_10%,transparent)] px-2.5 py-1 text-xs font-medium text-[var(--accent-blue)]"
                 >
@@ -1034,7 +1160,10 @@ export function ProblemCards({
             the doubled border) and read as a unit rather than as two
             unrelated dropdowns. */}
         <div className="inline-flex shrink-0 items-center gap-2">
-          <label htmlFor="sort" className="shrink-0 text-xs text-[var(--ink-muted)]">
+          <label
+            htmlFor="sort"
+            className="shrink-0 text-xs text-[var(--ink-muted)]"
+          >
             Sort by
           </label>
           <span className="inline-flex">
@@ -1057,7 +1186,10 @@ export function ProblemCards({
             </select>
             <button
               type="button"
-              onClick={() => { touch(); setSortDir((d) => (d === "asc" ? "desc" : "asc")); }}
+              onClick={() => {
+                touch();
+                setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+              }}
               // Announces the state AND what pressing does; "Sort ascending"
               // alone was ambiguous about which of the two it meant.
               aria-label={`Sorted ${sortDir === "asc" ? "ascending" : "descending"}. Switch to ${
@@ -1066,7 +1198,10 @@ export function ProblemCards({
               title={sortDir === "asc" ? "Ascending" : "Descending"}
               className="-ml-px inline-flex h-9 min-w-9 shrink-0 items-center justify-center gap-1.5 rounded-r border border-[var(--hairline)] bg-[var(--paper-raised)] px-2 text-xs text-[var(--ink-secondary)] transition-colors hover:border-[var(--ink-muted)] hover:text-[var(--ink)] focus:relative focus:z-10 focus:outline-none focus:ring-1 focus:ring-[var(--accent-blue)]"
             >
-              <Icon name="arrowDown" className={sortDir === "asc" ? "rotate-180" : ""} />
+              <Icon
+                name="arrowDown"
+                className={sortDir === "asc" ? "rotate-180" : ""}
+              />
               {/* The word is the icon's gloss, not its replacement: it costs
                   ~90px, which a phone cannot spare and a desktop never
                   notices. The title and aria-label carry it on mobile. */}
@@ -1091,13 +1226,19 @@ export function ProblemCards({
             pills would wrap onto its own row on phones, and the dropdown
             leaves room to add windows later without spending width. */}
         <div className="inline-flex shrink-0 items-center gap-2">
-          <label htmlFor="period" className="shrink-0 text-xs text-[var(--ink-muted)]">
+          <label
+            htmlFor="period"
+            className="shrink-0 text-xs text-[var(--ink-muted)]"
+          >
             Period
           </label>
           <select
             id="period"
             value={period}
-            onChange={(e) => { touch(); setPeriod(e.target.value as Period); }}
+            onChange={(e) => {
+              touch();
+              setPeriod(e.target.value as Period);
+            }}
             className={selectClass}
           >
             {PERIODS.map((p) => (
@@ -1121,8 +1262,10 @@ export function ProblemCards({
           ) : (
             <>
               showing{" "}
-              <span className="font-medium text-[var(--ink-secondary)]">{sorted.length}</span> of{" "}
-              {problems.length} entries
+              <span className="font-medium text-[var(--ink-secondary)]">
+                {sorted.length}
+              </span>{" "}
+              of {problems.length} entries
             </>
           )}
         </span>
@@ -1139,7 +1282,9 @@ export function ProblemCards({
             <ProblemCard
               key={p.slug}
               p={p}
-              statementHtml={p.statementHtml ?? lateStatements?.[p.slug] ?? null}
+              statementHtml={
+                p.statementHtml ?? lateStatements?.[p.slug] ?? null
+              }
             />
           ))}
         </div>
@@ -1157,7 +1302,10 @@ export function ProblemCards({
         </button>
         {pageWindow(current, totalPages).map((p, i) =>
           p === "gap" ? (
-            <span key={`gap-${i}`} className="px-1 text-sm text-[var(--ink-muted)]">
+            <span
+              key={`gap-${i}`}
+              className="px-1 text-sm text-[var(--ink-muted)]"
+            >
               …
             </span>
           ) : (
@@ -1186,7 +1334,10 @@ export function ProblemCards({
 
         <select
           value={perPage}
-          onChange={(e) => { touch(); setPerPage(Number(e.target.value)); }}
+          onChange={(e) => {
+            touch();
+            setPerPage(Number(e.target.value));
+          }}
           aria-label="Entries per page"
           className={`${selectClass} ml-auto`}
         >

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -16,7 +16,12 @@
 import type { Prisma } from "@prisma/client";
 import { cacheLife, cacheTag } from "next/cache";
 import { prisma } from "@/lib/prisma";
-import { activityTag, commentsTag, subjectWhere, type Subject } from "@/lib/subject";
+import {
+  activityTag,
+  commentsTag,
+  subjectWhere,
+  type Subject,
+} from "@/lib/subject";
 import type { ProfileLinks } from "@/lib/profile-links";
 import {
   CHANGELOG_TYPES,
@@ -89,6 +94,7 @@ export const PROBLEM_SELECT = {
   sourceUrl: true,
   sourceName: true,
   createdAt: true,
+  updatedAt: true,
   links: {
     select: { label: true, url: true, kind: true },
     orderBy: { position: "asc" },
@@ -153,7 +159,11 @@ export function toProblem(r: ProblemRow): ProblemWithVotes {
     sourceUrl: r.sourceUrl,
     sourceName: r.sourceName,
     links: r.links.map((l) => ({ label: l.label, url: l.url, kind: l.kind })),
-    relations: r.relationsFrom.map((x) => ({ to: x.to.slug, kind: x.kind, note: x.note })),
+    relations: r.relationsFrom.map((x) => ({
+      to: x.to.slug,
+      kind: x.kind,
+      note: x.note,
+    })),
     upvotes: r.upvotes,
     downvotes: r.downvotes,
     score: r.upvotes - r.downvotes,
@@ -161,6 +171,7 @@ export function toProblem(r: ProblemRow): ProblemWithVotes {
     // Null for the curated baseline; a pseudonym for community submissions.
     submittedBy: r.submittedBy?.pseudonym ?? null,
     addedAt: r.createdAt.toISOString(),
+    changedAt: r.updatedAt.toISOString(),
   };
 }
 
@@ -201,7 +212,8 @@ async function countsSince(since: Date): Promise<WindowCounts> {
   const commentCounts = new Map<string, number>();
   for (const row of comments) {
     // Record comments group under a null problemId; entry counts skip them.
-    if (row.problemId !== null) commentCounts.set(row.problemId, row._count._all);
+    if (row.problemId !== null)
+      commentCounts.set(row.problemId, row._count._all);
   }
 
   return { score, comments: commentCounts };
@@ -230,19 +242,28 @@ export async function getToday(): Promise<string> {
   return new Date().toISOString().slice(0, 10);
 }
 
-export async function getEntryFlow(): Promise<{ week: number; prevWeek: number }> {
+export async function getEntryFlow(): Promise<{
+  week: number;
+  prevWeek: number;
+}> {
   "use cache";
   cacheTag("problems");
   cacheLife("hours");
   const now = Date.now();
   const [week, prevWeek] = await Promise.all([
     prisma.problem.count({
-      where: { status: "published", createdAt: { gte: new Date(now - 7 * DAY_MS) } },
+      where: {
+        status: "published",
+        createdAt: { gte: new Date(now - 7 * DAY_MS) },
+      },
     }),
     prisma.problem.count({
       where: {
         status: "published",
-        createdAt: { gte: new Date(now - 14 * DAY_MS), lt: new Date(now - 7 * DAY_MS) },
+        createdAt: {
+          gte: new Date(now - 14 * DAY_MS),
+          lt: new Date(now - 7 * DAY_MS),
+        },
       },
     }),
   ]);
@@ -340,7 +361,13 @@ export async function getRelations(slug: string): Promise<RelationView[]> {
 
   const rows = await prisma.problemRelation.findMany({
     where: { OR: [{ from: { slug } }, { to: { slug } }] },
-    select: { kind: true, note: true, position: true, from: { select: TARGET }, to: { select: TARGET } },
+    select: {
+      kind: true,
+      note: true,
+      position: true,
+      from: { select: TARGET },
+      to: { select: TARGET },
+    },
     orderBy: [{ position: "asc" }, { createdAt: "asc" }],
   });
 
@@ -428,7 +455,14 @@ export async function getProvenance(slug: string): Promise<ProvenanceView[]> {
 
   const rows = await prisma.fieldProvenance.findMany({
     where: { problem: { slug } },
-    select: { field: true, model: true, source: true, userName: true, userId: true, createdAt: true },
+    select: {
+      field: true,
+      model: true,
+      source: true,
+      userName: true,
+      userId: true,
+      createdAt: true,
+    },
   });
   return rows.map((r) => ({
     field: r.field,
@@ -531,7 +565,10 @@ export async function getRecentActivity(
               field: a.field,
               oldValue: a.oldValue,
               newValue: a.newValue,
-              createdAt: relativeFallback(a.createdAt, formatCommentDate(a.createdAt)),
+              createdAt: relativeFallback(
+                a.createdAt,
+                formatCommentDate(a.createdAt),
+              ),
               createdAtIso: a.createdAt.toISOString(),
               problemName: a.problem.name,
               problemSlug: a.problem.slug,
@@ -673,26 +710,28 @@ export async function getMemberDirectory(): Promise<DirectoryMember[]> {
     },
   });
 
-  return users
-    .map((u) => ({
-      pseudonym: u.pseudonym as string,
-      role: u.role,
-      verified: u.verified,
-      contributions:
-        u._count.submittedProblems + u._count.comments + u._count.activities,
-      entries: u._count.submittedProblems,
-      comments: u._count.comments,
-      edits: u._count.activities,
-      joined: formatCommentDate(u.createdAt),
-    }))
-    // Most active first, then alphabetical so the long tail of members with
-    // identical counts has a stable, findable order rather than whatever the
-    // database returned.
-    .sort(
-      (a, b) =>
-        b.contributions - a.contributions ||
-        a.pseudonym.localeCompare(b.pseudonym),
-    );
+  return (
+    users
+      .map((u) => ({
+        pseudonym: u.pseudonym as string,
+        role: u.role,
+        verified: u.verified,
+        contributions:
+          u._count.submittedProblems + u._count.comments + u._count.activities,
+        entries: u._count.submittedProblems,
+        comments: u._count.comments,
+        edits: u._count.activities,
+        joined: formatCommentDate(u.createdAt),
+      }))
+      // Most active first, then alphabetical so the long tail of members with
+      // identical counts has a stable, findable order rather than whatever the
+      // database returned.
+      .sort(
+        (a, b) =>
+          b.contributions - a.contributions ||
+          a.pseudonym.localeCompare(b.pseudonym),
+      )
+  );
 }
 
 /// Public profile by CURRENT pseudonym, or null when no such member exists.
@@ -751,15 +790,15 @@ export async function getUserProfile(
       // not publish something is not to read it.
       user.showComments
         ? prisma.comment.findMany({
-        where: { userId: user.id, ...publishedOnly },
-        orderBy: { createdAt: "desc" },
-        take: 50,
-        select: {
-          id: true,
-          body: true,
-          createdAt: true,
-          problem: { select: { name: true, slug: true } },
-        },
+            where: { userId: user.id, ...publishedOnly },
+            orderBy: { createdAt: "desc" },
+            take: 50,
+            select: {
+              id: true,
+              body: true,
+              createdAt: true,
+              problem: { select: { name: true, slug: true } },
+            },
           })
         : Promise.resolve([]),
       // Counted either way: it feeds `contributions`, which is one blended
@@ -910,12 +949,20 @@ export async function getTeam(): Promise<TeamMember[]> {
       showGoogleName: true,
     },
   });
-  const order: Record<string, number> = { admin: 0, moderator: 1, developer: 2 };
+  const order: Record<string, number> = {
+    admin: 0,
+    moderator: 1,
+    developer: 2,
+  };
   return rows
-    .filter((r): r is typeof r & { pseudonym: string; staffRole: string } => !!r.pseudonym && !!r.staffRole)
+    .filter(
+      (r): r is typeof r & { pseudonym: string; staffRole: string } =>
+        !!r.pseudonym && !!r.staffRole,
+    )
     .map((r) => ({
       pseudonym: r.pseudonym,
-      displayName: r.showGoogleName && r.name?.trim() ? r.name.trim() : r.pseudonym,
+      displayName:
+        r.showGoogleName && r.name?.trim() ? r.name.trim() : r.pseudonym,
       staffRole: r.staffRole,
       verified: r.verified,
       bio: r.bio,
@@ -1008,7 +1055,10 @@ export async function getPendingQueue(): Promise<QueueEntry[]> {
     name: r.name,
     field: r.field,
     fieldGroup: r.fieldGroup,
-    submittedBy: resolveSnapshot(r.submittedBy?.pseudonym ?? null, r.submittedBy !== null),
+    submittedBy: resolveSnapshot(
+      r.submittedBy?.pseudonym ?? null,
+      r.submittedBy !== null,
+    ),
     submittedAtIso: r.createdAt.toISOString(),
     submittedAt: relativeFallback(r.createdAt, formatCommentDate(r.createdAt)),
   }));
@@ -1100,7 +1150,9 @@ const FRONTIER_ROW_SELECT = {
   },
 } satisfies Prisma.FrontierRowSelect;
 
-type FrontierRowRaw = Prisma.FrontierRowGetPayload<{ select: typeof FRONTIER_ROW_SELECT }>;
+type FrontierRowRaw = Prisma.FrontierRowGetPayload<{
+  select: typeof FRONTIER_ROW_SELECT;
+}>;
 
 function toFrontierRow(r: FrontierRowRaw): FrontierRowView {
   // An entry that has been unpublished since the row was made must not leak
@@ -1162,7 +1214,9 @@ export async function getFrontiers(): Promise<FrontierSummary[]> {
   }));
 }
 
-export async function getFrontierBySlug(slug: string): Promise<FrontierView | null> {
+export async function getFrontierBySlug(
+  slug: string,
+): Promise<FrontierView | null> {
   "use cache";
   cacheTag("frontiers", `frontier-${slug}`);
   cacheLife("hours");
@@ -1203,8 +1257,16 @@ export async function getFrontierBySlug(slug: string): Promise<FrontierView | nu
 
 /// The records an entry is a row on, for the one-line pointer on its page.
 /// Almost every entry has none, so this must stay cheap: one indexed lookup.
-export async function getFrontiersForProblem(slug: string): Promise<
-  { slug: string; shortName: string; direction: "min" | "max"; rows: FrontierRowView[]; rowId: string }[]
+export async function getFrontiersForProblem(
+  slug: string,
+): Promise<
+  {
+    slug: string;
+    shortName: string;
+    direction: "min" | "max";
+    rows: FrontierRowView[];
+    rowId: string;
+  }[]
 > {
   "use cache";
   cacheTag("frontiers", `problem-${slug}`);
@@ -1215,7 +1277,12 @@ export async function getFrontiersForProblem(slug: string): Promise<
     select: {
       id: true,
       frontier: {
-        select: { slug: true, shortName: true, direction: true, rows: { select: FRONTIER_ROW_SELECT } },
+        select: {
+          slug: true,
+          shortName: true,
+          direction: true,
+          rows: { select: FRONTIER_ROW_SELECT },
+        },
       },
     },
   });

--- a/src/lib/list-settings.ts
+++ b/src/lib/list-settings.ts
@@ -29,6 +29,7 @@ import { MODEL_FAMILIES, SOLVE_TYPE, VERIFICATION } from "@/lib/display";
 export type SortKey =
   | "solveDate"
   | "added"
+  | "changed"
   | "score"
   | "discussion"
   | "name"
@@ -46,6 +47,7 @@ export const SORTS: { key: SortKey; label: string }[] = [
   { key: "added", label: "Date added" },
   { key: "solveDate", label: "Date solved" },
   { key: "cost", label: "Disclosed cost" },
+  { key: "changed", label: "Last changed" },
   { key: "name", label: "Name" },
   { key: "significance", label: "Significance" },
   { key: "score", label: "Votes" },
@@ -81,6 +83,7 @@ export const TIME_SENSITIVE: SortKey[] = ["score", "discussion"];
 export const NUMERIC_KEYS: SortKey[] = [
   "solveDate",
   "added",
+  "changed",
   "age",
   "significance",
   "score",
@@ -117,10 +120,15 @@ export function joinSelection(values: string[]): Selection {
 /// Adds an option to a facet, or removes it if it is already chosen. This is
 /// the only way the UI changes a facet, so clicking an active pill still
 /// clears it exactly as it did when facets held one value.
-export function toggleSelection(value: Selection | undefined, option: string): Selection {
+export function toggleSelection(
+  value: Selection | undefined,
+  option: string,
+): Selection {
   const chosen = parseSelection(value);
   return joinSelection(
-    chosen.includes(option) ? chosen.filter((v) => v !== option) : [...chosen, option],
+    chosen.includes(option)
+      ? chosen.filter((v) => v !== option)
+      : [...chosen, option],
   );
 }
 
@@ -185,30 +193,43 @@ export const SETTINGS_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
 /// hand-edited URL cannot make one condition count twice in the badge.
 const sanitize = (value: unknown, allowed: readonly string[]): Selection => {
   if (typeof value !== "string") return "all";
-  return joinSelection([...new Set(parseSelection(value))].filter((v) => allowed.includes(v)));
+  return joinSelection(
+    [...new Set(parseSelection(value))].filter((v) => allowed.includes(v)),
+  );
 };
 
 /// Validates whatever was stored into settings the UI can actually render.
 /// Anything unrecognised falls back to its default, key by key, so one stale
 /// filter cannot discard the rest of a remembered view.
 export function normalizeListSettings(raw: unknown): ListSettings {
-  const s = (typeof raw === "object" && raw !== null ? raw : {}) as Record<string, unknown>;
+  const s = (typeof raw === "object" && raw !== null ? raw : {}) as Record<
+    string,
+    unknown
+  >;
   const out = { ...DEFAULT_SETTINGS };
 
   out.fieldFilter = sanitize(s.fieldFilter, FIELD_GROUPS);
   out.resultFilter = sanitize(s.resultFilter, Object.keys(SOLVE_TYPE));
   out.statusFilter = sanitize(s.statusFilter, RESOLUTION_STATUSES);
   out.contributionFilter = sanitize(s.contributionFilter, AI_CONTRIBUTIONS);
-  out.modelFilter = sanitize(s.modelFilter, MODEL_FAMILIES.map((f) => f.key));
-  out.verificationFilter = sanitize(s.verificationFilter, Object.keys(VERIFICATION));
+  out.modelFilter = sanitize(
+    s.modelFilter,
+    MODEL_FAMILIES.map((f) => f.key),
+  );
+  out.verificationFilter = sanitize(
+    s.verificationFilter,
+    Object.keys(VERIFICATION),
+  );
   out.publicationFilter = sanitize(s.publicationFilter, PUBLICATION_STATUSES);
   out.methodFilter = sanitize(s.methodFilter, RESOLUTION_METHODS);
   out.sourceFilter = sanitize(s.sourceFilter, SOURCE_HOST_KEYS);
 
-  if (SORTS.some((x) => x.key === s.sortKey)) out.sortKey = s.sortKey as SortKey;
+  if (SORTS.some((x) => x.key === s.sortKey))
+    out.sortKey = s.sortKey as SortKey;
   if (s.sortDir === "asc" || s.sortDir === "desc") out.sortDir = s.sortDir;
   if (PERIODS.some((x) => x.key === s.period)) out.period = s.period as Period;
-  if (typeof s.perPage === "number" && PAGE_SIZES.includes(s.perPage)) out.perPage = s.perPage;
+  if (typeof s.perPage === "number" && PAGE_SIZES.includes(s.perPage))
+    out.perPage = s.perPage;
 
   return out;
 }
@@ -253,13 +274,22 @@ export function solveDateSortKey(solveDate: string): string {
 /// The value a card sorts on. Shared so the server can order the list the
 /// same way the client will, which is what lets the page inline statement
 /// math for the entries that will actually be on screen.
-export function sortValue(p: CardEntry, key: SortKey, period: Period): string | number {
+export function sortValue(
+  p: CardEntry,
+  key: SortKey,
+  period: Period,
+): string | number {
   switch (key) {
     case "solveDate":
       return solveDateSortKey(p.solveDate);
     case "added":
       // ISO timestamps sort correctly as strings.
       return p.addedAt;
+    case "changed":
+      // Most recently touched first: an edit, a review decision, a vote. The
+      // stamp is the row's own updatedAt, so a comment (its own table) does
+      // not count as a change to the entry - "Comments" is the sort for that.
+      return p.changedAt;
     case "score":
       // "Top voted" ranks on NET score, not raw upvotes - otherwise a
       // 50-up/49-down brawl outranks a clean 20-up/0-down entry.

--- a/src/lib/problems.ts
+++ b/src/lib/problems.ts
@@ -285,6 +285,7 @@ export type ProblemWithVotes = MathProblem & {
   /// ISO timestamp of when the entry was added to the record (row creation) -
   /// distinct from `solveDate`, which is when the mathematics happened.
   addedAt: string;
+  changedAt: string;
 };
 
 /// A problem plus engagement inside recent time windows.
@@ -360,6 +361,8 @@ export interface CardEntry {
   commentCount: number;
   submittedBy: string | null;
   addedAt: string;
+  /** ISO timestamp of the row's last update: edits, review decisions, votes. */
+  changedAt: string;
   /** Where the entry's primary source points, so a card can offer it directly. */
   sourceUrl: string;
   sourceName: string;
@@ -407,12 +410,26 @@ export function assertProblem(value: unknown, index: number): MathProblem {
     }
   };
 
-  ["slug", "name", "shortName", "solveDate", "model", "sourceUrl", "sourceName"].forEach(
-    requireString,
-  );
-  ["field", "statement", "posedBy", "modelMaker", "aiRole", "verificationNote", "citationsPaper", "citationsSource", "citationsUrl"].forEach(
-    requireNullableString,
-  );
+  [
+    "slug",
+    "name",
+    "shortName",
+    "solveDate",
+    "model",
+    "sourceUrl",
+    "sourceName",
+  ].forEach(requireString);
+  [
+    "field",
+    "statement",
+    "posedBy",
+    "modelMaker",
+    "aiRole",
+    "verificationNote",
+    "citationsPaper",
+    "citationsSource",
+    "citationsUrl",
+  ].forEach(requireNullableString);
   ["problemNumber", "yearPosed", "citations"].forEach(requireNullableNumber);
   requireNumber("renownLangs");
   for (const key of [
@@ -423,19 +440,25 @@ export function assertProblem(value: unknown, index: number): MathProblem {
     "significanceNote",
   ]) {
     if (p[key] !== undefined && p[key] !== null && typeof p[key] !== "string") {
-      throw new Error(`${where}: "${key}" must be a string or null when present`);
+      throw new Error(
+        `${where}: "${key}" must be a string or null when present`,
+      );
     }
   }
   if (p.significance !== undefined && p.significance !== null) {
     const s = p.significance;
     if (typeof s !== "number" || !Number.isInteger(s) || s < 0 || s > 100) {
-      throw new Error(`${where}: "significance" must be an integer 0-100 when present`);
+      throw new Error(
+        `${where}: "significance" must be an integer 0-100 when present`,
+      );
     }
   }
   requireStringArray("humanCollaborators");
 
   if (!SOLVE_TYPES.includes(p.solveType as SolveType)) {
-    throw new Error(`${where}: "solveType" must be one of ${SOLVE_TYPES.join(", ")}`);
+    throw new Error(
+      `${where}: "solveType" must be one of ${SOLVE_TYPES.join(", ")}`,
+    );
   }
   if (!RESOLUTION_STATUSES.includes(p.resolution as ResolutionStatus)) {
     throw new Error(
@@ -454,7 +477,9 @@ export function assertProblem(value: unknown, index: number): MathProblem {
   }
   // The curated baseline always classifies; only community rows may lack it.
   if (!FIELD_GROUPS.includes(p.fieldGroup as FieldGroup)) {
-    throw new Error(`${where}: "fieldGroup" must be one of ${FIELD_GROUPS.join(", ")}`);
+    throw new Error(
+      `${where}: "fieldGroup" must be one of ${FIELD_GROUPS.join(", ")}`,
+    );
   }
   if (p.links !== undefined) {
     const ok =
@@ -467,7 +492,9 @@ export function assertProblem(value: unknown, index: number): MathProblem {
           typeof (l as LinkRef).url === "string",
       );
     if (!ok) {
-      throw new Error(`${where}: "links" must be an array of { label, url } when present`);
+      throw new Error(
+        `${where}: "links" must be an array of { label, url } when present`,
+      );
     }
   }
   if (p.relations !== undefined) {
@@ -482,7 +509,9 @@ export function assertProblem(value: unknown, index: number): MathProblem {
           typeof (r as { note: unknown }).note === "string",
       );
     if (!ok) {
-      throw new Error(`${where}: "relations" must be an array of { to, kind, note } when present`);
+      throw new Error(
+        `${where}: "relations" must be an array of { to, kind, note } when present`,
+      );
     }
   }
   if (!VERIFICATION_STATUSES.includes(p.verification as VerificationStatus)) {
@@ -537,7 +566,9 @@ export type ChartProblem = Pick<
   | "significance"
 >;
 
-export function ageAtSolve(problem: Pick<MathProblem, "yearPosed" | "solveDate">): number | null {
+export function ageAtSolve(
+  problem: Pick<MathProblem, "yearPosed" | "solveDate">,
+): number | null {
   if (problem.yearPosed === null) return null;
   const solveYear = parseInt(problem.solveDate.slice(0, 4), 10);
   if (Number.isNaN(solveYear)) return null;


### PR DESCRIPTION
A "Last changed" sort on the front-page list: orders by the row's `updatedAt` (edits, review decisions, votes), most recent first. Comments are their own table and do not bump it; the "Comments" sort covers those. The period filter scopes by the same stamp, as "Date added" does by `createdAt`. One new field on the card DTO, one line in the server projection, one case in `sortValue`.

**Verify:** the sort dropdown lists "Last changed" between "Disclosed cost" and "Name"; picking it puts the most recently edited entries first; with "Last 7 days" only entries touched this week remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFTGCPuEuBPFPtnczbPFZm