### PR TITLE
Header on phones: two rows at every width

### DIFF
--- a/src/components/CommunityLinks.tsx
+++ b/src/components/CommunityLinks.tsx
@@ -1,7 +1,7 @@
 import { DISCORD_INVITE, X_PROFILE } from "@/lib/community";
 
 const communityLink =
-  "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md " +
+  "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md sm:h-7 sm:w-7 " +
   "transition-opacity hover:opacity-70 focus:outline-none focus-visible:outline-2 " +
   "focus-visible:outline-offset-1 focus-visible:outline-[var(--accent-blue)]";
 
@@ -31,7 +31,11 @@ const communityLink =
 /// dark) are explained beside `.x-mark-hollow` in globals.css.
 export function CommunityLinks() {
   return (
-    <span role="group" aria-label="Community" className="ml-1 flex shrink-0 items-center gap-0.5">
+    <span
+      role="group"
+      aria-label="Community"
+      className="ml-auto flex shrink-0 items-center gap-0.5 lg:ml-1"
+    >
       <a
         href={DISCORD_INVITE}
         target="_blank"
@@ -40,7 +44,12 @@ export function CommunityLinks() {
         aria-label="Join the community on Discord (opens in a new tab)"
         className={`${communityLink} text-[var(--brand-discord)]`}
       >
-        <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+        <svg
+          className="h-[18px] w-[18px] sm:h-[22px] sm:w-[22px]"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden
+        >
           <path d="M19.27 5.33A16.6 16.6 0 0 0 15.16 4c-.18.32-.39.75-.53 1.09a15.4 15.4 0 0 0-4.26 0C10.23 4.75 10.02 4.32 9.83 4a16.6 16.6 0 0 0-4.11 1.33C3.1 9.26 2.39 13.08 2.74 16.85a16.7 16.7 0 0 0 5.06 2.57c.41-.56.77-1.15 1.08-1.77-.59-.22-1.16-.5-1.69-.82.14-.1.28-.21.41-.32a11.9 11.9 0 0 0 10.2 0c.14.11.27.22.41.32-.54.32-1.11.6-1.7.82.31.62.67 1.21 1.08 1.77a16.6 16.6 0 0 0 5.06-2.57c.42-4.37-.72-8.16-2.38-11.52ZM9.16 14.55c-.99 0-1.8-.9-1.8-2.01 0-1.11.79-2.01 1.8-2.01 1.01 0 1.82.9 1.8 2.01 0 1.11-.8 2.01-1.8 2.01Zm5.68 0c-.99 0-1.8-.9-1.8-2.01 0-1.11.79-2.01 1.8-2.01 1.01 0 1.82.9 1.8 2.01 0 1.11-.79 2.01-1.8 2.01Z" />
         </svg>
       </a>
@@ -52,7 +61,11 @@ export function CommunityLinks() {
         aria-label="Follow VibeMathed updates on X (opens in a new tab)"
         className={`${communityLink} text-[var(--brand-x)]`}
       >
-        <svg width="23" height="23" viewBox="0 0 24 24" aria-hidden>
+        <svg
+          className="h-[19px] w-[19px] sm:h-[23px] sm:w-[23px]"
+          viewBox="0 0 24 24"
+          aria-hidden
+        >
           <mask id="x-mark-knockout">
             <rect width="24" height="24" rx="5" fill="white" />
             <path

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -46,15 +46,20 @@ export function NavLinks() {
     // first link's text with the logo despite the links' own padding); from
     // `lg` it sits inline between the logo and the account button.
     //
-    // The inline breakpoint used to be `sm`. Promoting Members to the bar and
-    // seating Discord and X beside About made the row too wide for a tablet,
-    // so tablets now get the two-row layout phones always had. That is a
-    // deliberate trade: the member directory is a first-class destination as
-    // the community grows, and it outranks one row of chrome at 640-1024px.
-    // The footer's earlier note that Members should stay out of the bar was
-    // written before that was true.
+    // The inline breakpoint used to be `sm`. Seating Discord and X beside
+    // About made the row too wide for a tablet, so tablets get the two-row
+    // layout phones always had.
+    //
+    // Below `lg` the row does not wrap: it scrolls sideways, scrollbar hidden,
+    // bleeding to the right page edge. On a 360px phone the five sections plus
+    // the two marks are ~30px too wide for the row, and wrapping put the two
+    // marks alone on a third header row, which read as debris. A row that
+    // scrolls keeps the header two rows tall at every width; on a 412px phone
+    // nothing actually scrolls. The marks sit at the row's right end below
+    // `lg` (sections left, outposts right) and beside About from `lg`, where
+    // the row is inline and has no far end to speak of.
     <nav
-      className="order-3 -ml-1.5 flex w-full flex-wrap items-center gap-x-0 gap-y-1 lg:order-2 lg:ml-0 lg:w-auto lg:flex-nowrap lg:gap-1"
+      className="order-3 -ml-1.5 flex w-full items-center gap-x-0 gap-y-1 max-lg:-mr-4 max-lg:flex-nowrap max-lg:overflow-x-auto max-lg:whitespace-nowrap max-lg:pr-4 max-lg:[scrollbar-width:none] max-lg:[&::-webkit-scrollbar]:hidden sm:max-lg:-mr-8 sm:max-lg:pr-8 lg:order-2 lg:ml-0 lg:w-auto lg:gap-1"
       aria-label="Site"
     >
       {LINKS.map(({ href, label }) => {
@@ -64,7 +69,7 @@ export function NavLinks() {
             key={href}
             href={href}
             aria-current={active ? "page" : undefined}
-            className={`rounded-md px-1.5 py-1.5 text-sm transition-colors sm:px-2.5 ${
+            className={`rounded-md px-1 py-1.5 text-[13px] transition-colors sm:px-2.5 sm:text-sm ${
               active
                 ? "bg-[var(--paper)] font-medium text-[var(--ink)] shadow-[inset_0_0_0_1px_var(--hairline)]"
                 : "text-[var(--ink-secondary)] hover:text-[var(--ink)]"

--- a/src/components/ReviewBadge.tsx
+++ b/src/components/ReviewBadge.tsx
@@ -48,9 +48,12 @@ export function ReviewBadge() {
 
   if (!loaded || !isAdmin || pendingReviews <= 0) return null;
 
-  const waited = oldestPendingAt && now !== null ? relativeTime(oldestPendingAt, now) : null;
+  const waited =
+    oldestPendingAt && now !== null ? relativeTime(oldestPendingAt, now) : null;
   const label = `${pendingReviews} to review`;
-  const detail = waited ? `Oldest submitted ${waited}` : "Submissions awaiting review";
+  const detail = waited
+    ? `Oldest submitted ${waited}`
+    : "Submissions awaiting review";
 
   return (
     <Link
@@ -67,7 +70,13 @@ export function ReviewBadge() {
         "focus-visible:outline-[var(--accent-blue)]"
       }
     >
-      {label}
+      {/* On a phone the pill shows the count alone. Spelled out, "13 to
+          review" made the curator's control cluster wider than the space
+          beside the wordmark, so the whole cluster wrapped under it and the
+          header ran to four rows. The words come back from `sm`; the
+          aria-label and tooltip always carry them. */}
+      {pendingReviews}
+      <span className="hidden sm:inline">&nbsp;to review</span>
     </Link>
   );
 }


### PR DESCRIPTION
Two causes of the sprawling phone header, both fixed:

- **Curators:** the "13 to review" pill made the control cluster too wide to sit beside the wordmark, so the whole cluster wrapped under it (four header rows). Below `sm` the pill shows the count alone; the words return from `sm`; aria-label and tooltip always carry them.
- **Everyone:** below about 390px the Discord and X marks wrapped onto a third row. The section row no longer wraps below `lg`: 13px links with tighter padding, 24px marks at the row's right end, sideways scroll with hidden scrollbar as the fallback for narrower devices.

Measured with headless Chrome at 320, 360 and 412px: header height 97px at all three (was 129px at 360).

**Verify:** on a phone, signed in as curator with a non-empty queue, the header is two rows: wordmark plus controls, then sections with the two marks at the right end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmGH6wi2EMc1zF2AUhHU9U