### PR TITLE
README: the site icon beside the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VibeMathed
+# <img src="src/app/icon.svg" width="30" height="30" align="middle" alt=""> VibeMathed
 
 **[vibemathed.com](https://vibemathed.com)** is a community of mathematicians
 and enthusiasts tracking, curating and cataloguing the mathematical problems


### PR DESCRIPTION
The favicon, `src/app/icon.svg`, inline at the left of the README title, so the repository page and the site read as one thing.

- Referenced at its existing path rather than copied to the repo root: one file, no drift when the mark changes.
- The icon carries its own rounded-blue ground, so no light/dark variant is needed.
- Verified against GitHub's `/markdown` API that the sanitizer keeps `width`, `height` and `align`; the heading still renders as `VibeMathed` for anchors and outlines, since the `alt` is empty.

**Verify:** the repository front page shows the mark beside the title, vertically centred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwwKTgFYw3zQGxEvUahUiV