### PR TITLE
Accept LaTeX's other math delimiters

### DIFF
--- a/scripts/audit-paren-delimiters.ts
+++ b/scripts/audit-paren-delimiters.ts
@@ -1,0 +1,64 @@
+// How many published entries use LaTeX's \( \) / \[ \] math delimiters, which
+// the site's tokenizer did not recognise before September 2026. Read-only.
+//
+// position() rather than Prisma's `contains`: LIKE treats a backslash as its
+// escape character, so `contains: "\\("` silently matches a plain "(" and
+// reports most of the catalog.
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const OPEN_PAREN = String.fromCharCode(92) + "(";
+const OPEN_BRACKET = String.fromCharCode(92) + "[";
+const FIELDS = [
+  "statement",
+  "resultNote",
+  "verificationNote",
+  "aiRole",
+  "significanceNote",
+] as const;
+
+async function connectWithRetry() {
+  for (let a = 1; a <= 6; a++) {
+    try {
+      await prisma.$queryRawUnsafe("SELECT 1");
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw new Error("database unreachable");
+}
+
+async function count(col: string, pat: string): Promise<number> {
+  const rows = await prisma.$queryRawUnsafe<{ n: number }[]>(
+    `SELECT count(*)::int AS n FROM "Problem" WHERE status = 'published' AND position($1 in coalesce("${col}", '')) > 0`,
+    pat,
+  );
+  return rows[0].n;
+}
+
+async function main() {
+  await connectWithRetry();
+  for (const [label, pat] of [
+    ["inline  \\( \\)", OPEN_PAREN],
+    ["display \\[ \\]", OPEN_BRACKET],
+  ] as const) {
+    const parts = await Promise.all(FIELDS.map((f) => count(f, pat)));
+    console.log(
+      `${label}: ` + FIELDS.map((f, i) => `${f}=${parts[i]}`).join(" "),
+    );
+  }
+  const rows = await prisma.$queryRawUnsafe<{ slug: string }[]>(
+    `SELECT slug FROM "Problem" WHERE status = 'published'
+       AND (position($1 in coalesce(statement,'')) > 0 OR position($1 in coalesce("resultNote",'')) > 0)
+     ORDER BY "createdAt" DESC LIMIT 15`,
+    OPEN_PAREN,
+  );
+  console.log(
+    `\naffected entries (newest first): ${rows.length ? rows.map((r) => r.slug).join(", ") : "none"}`,
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/src/components/TeX.tsx
+++ b/src/components/TeX.tsx
@@ -124,6 +124,12 @@ export function deTeX(s: string): string {
   // not pair with a real delimiter and swallow the sentence between them. A meta
   // description gets this wrong silently, which is how it went unnoticed.
   let out = s.replace(/(?<!\\)\$\$?((?:\\.|[^$\\])+)\$\$?/g, "$1");
+  // The other pair of delimiters the tokenizer accepts, `\(…\)` and `\[…\]`.
+  // Without this a meta description carries the backslashes into the search
+  // result, and the catch-all below deletes only commands made of letters, so
+  // they would survive it.
+  out = out.replace(/\\\[[\s\S]*?\\\]/g, (m) => m.slice(2, -2));
+  out = out.replace(/\\\([\s\S]*?\\\)/g, (m) => m.slice(2, -2));
   for (const [re, rep] of REPLACEMENTS) out = out.replace(re, rep);
   out = unescapeDollars(out);
   return (

--- a/src/lib/comment-render.ts
+++ b/src/lib/comment-render.ts
@@ -13,7 +13,13 @@
 
 import katex from "katex";
 import { linkifyEscaped } from "@/lib/linkify";
-import { TEX_TOKENS, isDisplayMath, isInlineMath, unescapeDollars } from "@/lib/tex-tokens";
+import {
+  TEX_TOKENS,
+  isDisplayMath,
+  isInlineMath,
+  mathBody,
+  unescapeDollars,
+} from "@/lib/tex-tokens";
 
 function escapeHtml(s: string): string {
   return s
@@ -24,7 +30,10 @@ function escapeHtml(s: string): string {
 }
 
 function renderMath(tex: string, display: boolean): string {
-  return katex.renderToString(tex, { throwOnError: false, displayMode: display });
+  return katex.renderToString(tex, {
+    throwOnError: false,
+    displayMode: display,
+  });
 }
 
 /// Plain text in, safe HTML out. Blank lines separate paragraphs; single
@@ -36,8 +45,8 @@ export function renderCommentHtml(text: string): string {
       const parts = paragraph.split(TEX_TOKENS);
       const inner = parts
         .map((part) => {
-          if (isDisplayMath(part)) return renderMath(part.slice(2, -2), true);
-          if (isInlineMath(part)) return renderMath(part.slice(1, -1), false);
+          if (isDisplayMath(part)) return renderMath(mathBody(part), true);
+          if (isInlineMath(part)) return renderMath(mathBody(part), false);
           const linked = linkifyEscaped(escapeHtml(part));
           return unescapeDollars(linked).replace(/\n/g, "<br />");
         })
@@ -52,8 +61,18 @@ export function renderCommentHtml(text: string): string {
 export function formatCommentDate(d: Date): string {
   const day = String(d.getUTCDate()).padStart(2, "0");
   const months = [
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
   ];
   return `${day} ${months[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
 }

--- a/src/lib/tex-render.ts
+++ b/src/lib/tex-render.ts
@@ -1,5 +1,11 @@
 import { linkifyEscaped } from "@/lib/linkify";
-import { TEX_TOKENS, isDisplayMath, isInlineMath, unescapeDollars } from "@/lib/tex-tokens";
+import {
+  TEX_TOKENS,
+  isDisplayMath,
+  isInlineMath,
+  mathBody,
+  unescapeDollars,
+} from "@/lib/tex-tokens";
 
 export type MathRenderer = (tex: string, display: boolean) => string;
 
@@ -21,8 +27,8 @@ export function renderTexToHtml(
   const parts = children.split(TEX_TOKENS);
   return parts
     .map((part, i) => {
-      if (isDisplayMath(part)) return renderMath(part.slice(2, -2), true);
-      if (isInlineMath(part)) return renderMath(part.slice(1, -1), false);
+      if (isDisplayMath(part)) return renderMath(mathBody(part), true);
+      if (isInlineMath(part)) return renderMath(mathBody(part), false);
 
       // Display math is already a block, so discard a newline touching it
       // rather than rendering a duplicate gap.

--- a/src/lib/tex-tokens.test.ts
+++ b/src/lib/tex-tokens.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { TEX_TOKENS, isDisplayMath, isInlineMath, unescapeDollars } from "@/lib/tex-tokens";
+import {
+  TEX_TOKENS,
+  isDisplayMath,
+  isInlineMath,
+  mathBody,
+  unescapeDollars,
+} from "@/lib/tex-tokens";
 import { deTeX, texToHtml } from "@/components/TeX";
 
 // The tokenizer is shared by the entry renderer, the comment renderer and the
@@ -21,6 +27,60 @@ describe("TEX_TOKENS", () => {
     const parts = split("Then $$\\sum_{k\\ge1} a_k$$ converges.");
     expect(parts.filter(isDisplayMath)).toEqual(["$$\\sum_{k\\ge1} a_k$$"]);
     expect(parts.filter(isInlineMath)).toEqual([]);
+  });
+
+  // LaTeX's other delimiters, added September 2026. The 19-dimensional
+  // kissing entry published with its whole statement as literal backslashes
+  // because nothing here matched them.
+  it("splits LaTeX's paren delimiters out of prose", () => {
+    const parts = split("Let \\(D\\subseteq\\mathbb F_2^{19}\\) be the code.");
+    expect(parts.filter(isInlineMath)).toEqual([
+      "\\(D\\subseteq\\mathbb F_2^{19}\\)",
+    ]);
+    expect(parts.filter(isDisplayMath)).toEqual([]);
+  });
+
+  it("splits LaTeX's bracket delimiters as display math", () => {
+    const parts = split("Then \\[\\sum_{k\\ge1} a_k\\] converges.");
+    expect(parts.filter(isDisplayMath)).toEqual(["\\[\\sum_{k\\ge1} a_k\\]"]);
+    expect(parts.filter(isInlineMath)).toEqual([]);
+  });
+
+  it("stops each paren segment at its OWN closing delimiter", () => {
+    // The trap: an escape-aware body would eat "\)" as an escape pair and run
+    // the first segment on to the last one in the field.
+    const parts = split("both \\(a\\) and \\(b\\) hold");
+    expect(parts.filter(isInlineMath)).toEqual(["\\(a\\)", "\\(b\\)"]);
+    expect(parts.filter((p) => !isInlineMath(p) && p)).toEqual([
+      "both ",
+      " and ",
+      " hold",
+    ]);
+  });
+
+  it("mathBody strips whichever delimiters were used", () => {
+    expect(mathBody("$x^2$")).toBe("x^2");
+    expect(mathBody("$$x^2$$")).toBe("x^2");
+    expect(mathBody("\\(x^2\\)")).toBe("x^2");
+    expect(mathBody("\\[x^2\\]")).toBe("x^2");
+  });
+
+  it("renders the paren forms as math rather than as prose", () => {
+    const html = texToHtml("Let \\(A\\subseteq D\\) be admissible.");
+    // Exactly one formula, and the delimiters are gone from the prose. The raw
+    // TeX still appears inside KaTeX's own MathML annotation, which is why
+    // this counts spans instead of grepping for the command.
+    expect(html.match(/class="katex"/g)?.length ?? 0).toBe(1);
+    expect(html).toContain("Let ");
+    expect(html).toContain(" be admissible.");
+    expect(html).not.toContain("katex-error");
+  });
+
+  it("deTeX drops the paren delimiters", () => {
+    // Spacing is the author's: "A\subseteq D" has no space before the command,
+    // and deTeX substitutes rather than reflows, exactly as for the $ forms.
+    expect(deTeX("Let \\(A\\subseteq D\\) hold")).toBe("Let A⊆ D hold");
+    expect(deTeX("Then \\[x + y\\] follows")).toBe("Then x + y follows");
   });
 
   it("does not treat an escaped dollar as a delimiter", () => {
@@ -78,7 +138,9 @@ describe("deTeX", () => {
   });
 
   it("keeps an escaped dollar as a literal dollar", () => {
-    expect(deTeX("a \\$10,000 prize for $n^2$")).toBe("a $10,000 prize for n^2");
+    expect(deTeX("a \\$10,000 prize for $n^2$")).toBe(
+      "a $10,000 prize for n^2",
+    );
   });
 
   it("flattens newlines for a meta tag", () => {

--- a/src/lib/tex-tokens.ts
+++ b/src/lib/tex-tokens.ts
@@ -21,15 +21,45 @@
 // backslash immediately before real math still mis-parses, because the
 // lookbehind cannot tell an escaped backslash from an escaping one. That costs a
 // regex several times this size to fix and has never occurred in the catalog.
+//
+// LaTeX's OTHER delimiters, `\(…\)` and `\[…\]`, are accepted too, since
+// September 2026. They are what someone who writes papers types, KaTeX's own
+// auto-render accepts them by default, and a submitter used them: the
+// 19-dimensional kissing entry published with its whole statement as literal
+// backslashes on screen, because nothing matched and the text fell through to
+// be escaped as prose. The site takes submissions from anyone, so this was
+// going to recur.
+//
+// These two use a lazy any-character run to the first closing delimiter
+// rather than the escape-aware body the dollar forms use. `(?:\\.|[^$\\])+`
+// would let `\)` be eaten as an escape pair and run the segment on to the
+// LAST `\)` in the field. Inside real math nobody writes `\)` for anything
+// but closing, so first-match is the right reading.
 export const TEX_TOKENS =
-  /((?<!\\)\$\$(?:\\.|[^$\\])+\$\$|(?<!\\)\$(?:\\.|[^$\\])+\$)/g;
+  /((?<!\\)\$\$(?:\\.|[^$\\])+\$\$|(?<!\\)\$(?:\\.|[^$\\])+\$|\\\[[\s\S]*?\\\]|\\\([\s\S]*?\\\))/g;
 
 export function isDisplayMath(part: string): boolean {
-  return part.startsWith("$$") && part.endsWith("$$") && part.length > 4;
+  return (
+    (part.startsWith("$$") && part.endsWith("$$") && part.length > 4) ||
+    (part.startsWith("\\[") && part.endsWith("\\]") && part.length > 4)
+  );
 }
 
 export function isInlineMath(part: string): boolean {
-  return !isDisplayMath(part) && part.startsWith("$") && part.endsWith("$") && part.length > 2;
+  if (isDisplayMath(part)) return false;
+  return (
+    (part.startsWith("$") && part.endsWith("$") && part.length > 2) ||
+    (part.startsWith("\\(") && part.endsWith("\\)") && part.length > 4)
+  );
+}
+
+/// The TeX inside a math segment, with whichever delimiters it arrived in
+/// removed. Shared because the two renderers used to slice by hand, and a
+/// hand-written `slice(1, -1)` is wrong the moment a two-character delimiter
+/// exists.
+export function mathBody(part: string): string {
+  if (part.startsWith("$") && !part.startsWith("$$")) return part.slice(1, -1);
+  return part.slice(2, -2);
 }
 
 /// Turns an author's `\$` into a literal dollar.


### PR DESCRIPTION
### The bug

The [19-dimensional kissing entry](https://vibemathed.com/problem/optimality-of-the-added-vector-code-in-the-19-dimensional-kissing-construction) shows its statement as literal backslashes:

> Let \(D\subseteq\mathbb F_2^{19}\) be the fixed 4096-word ambient binary linear code…

`TEX_TOKENS` knew only `$…$` and `$$…$$`. Nothing matched, so the statement fell through to be escaped as prose.

### The fix

Accept `\(…\)` and `\[…\]` too. They are what someone who writes papers types, KaTeX's own auto-render accepts them by default, and this site takes submissions from anyone, so it was going to recur. Both renderers (entries, comments) and `deTeX` (meta descriptions) handle them.

Two notes for whoever touches this next:

- The paren forms use a **lazy run to the first closing delimiter**, not the escape-aware body the dollar forms use. `(?:\.|[^$\])+` would eat `\)` as an escape pair and run one segment on to the *last* `\)` in the field. A test pins that.
- Delimiter stripping moved into a shared `mathBody()`: both renderers were slicing by hand, and `slice(1, -1)` is wrong the moment a two-character delimiter exists.

### Blast radius

One published entry, and it needs no edit: the renderer now reads what its author wrote. `scripts/audit-paren-delimiters.ts` is how that was counted. It uses `position()` rather than Prisma's `contains`, because LIKE treats a backslash as its escape character and `contains: "\("` silently matches a plain `(` — it reported 415 of 689 entries before that was caught.

86 tests pass (6 new), lint and typecheck clean, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wddi3MgHAsjbw3w9B18cn8