### PR TITLE
Promote main to production: LaTeX delimiter fix, docs refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,10 @@ commits.
 `production` is what vibemathed.com serves. Code reaches it by a deliberate
 promotion from `main`, never by momentum. You will not normally touch it.
 
-Do not target `staging`. It is being retired; anything opened against it
-should be retargeted to `main`.
-[`docs/branch-flow.md`](docs/branch-flow.md) explains the reasoning and lists
-the migration steps still outstanding.
+There is no longer a `staging` branch: the staging environment hangs off
+`main`, so merging to `main` is what puts a change in front of people.
+[`docs/branch-flow.md`](docs/branch-flow.md) explains the reasoning and records
+how the flow was migrated.
 
 ## Checks
 
@@ -89,20 +89,21 @@ a one-line fix.
 ## Branching and pull requests
 
 ```
-your-branch  --PR-->  staging  --PR-->  main
-                        |                 |
-                   staging site      vibemathed.com
+your-branch  --PR-->  main  --PR-->  production
+                       |                 |
+                 staging site      vibemathed.com
 ```
 
 - Branch from `main`.
-- Open your pull request against **`staging`**, not `main`. Staging has its own
-  database and its own OAuth apps, so you can sign in and click through your
-  change against real-looking data without touching production. See
-  [`docs/staging.md`](docs/staging.md) for how it is wired and how to refresh it.
-- Once it has been exercised on staging, it is promoted to `main` in a separate
-  pull request. `main` deploys to production on merge.
-- `main` is protected: it needs a green CI run and one approving review, and
-  cannot be pushed to directly.
+- Open your pull request against **`main`**. Merging it deploys to the staging
+  environment, which has its own database and its own OAuth apps, so you can
+  sign in and click through your change against real-looking data without
+  touching production. See [`docs/staging.md`](docs/staging.md) for how that
+  environment is wired.
+- Reaching vibemathed.com is a separate, deliberate step: a pull request from
+  `main` to `production`, merged when someone decides to release.
+- Both branches are protected: each needs a green CI run and one approving
+  review, and neither can be pushed to directly.
 
 Keep pull requests focused. An infrastructure fix and a feature belong in
 separate ones, and reviewing is much faster when a diff does one thing.
@@ -116,6 +117,7 @@ Every pull request runs [`.github/workflows/ci.yml`](.github/workflows/ci.yml):
 | Lint | `npm run lint` |
 | Types | `npm run typecheck` |
 | Prisma schema is valid | `npx prisma validate` |
+| Tests | `npm test` |
 | Formatting of `problems.json` | parsed and re-serialised |
 
 CI deliberately does **not** run `npm run build`. The build prerenders the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="src/app/icon.svg" width="30" height="30" align="middle" alt=""> VibeMathed
+# <img src="src/app/icon.svg" width="24" height="24" alt=""> VibeMathed
 
 **[vibemathed.com](https://vibemathed.com)** is a community of mathematicians
 and enthusiasts tracking, curating and cataloguing the mathematical problems

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ labeled as such rather than left out or overstated. The
 [methodology](https://vibemathed.com/methodology) documents what qualifies and
 how every label is assigned.
 
+689 published entries across twelve areas of mathematics, 480 of them fully
+resolved, and eight frontiers, as of 6 September 2026.
+[The stats page](https://vibemathed.com/stats) carries the live figures.
+
 ## What an entry carries
 
 - **Result** (proved / disproved) and **status** (resolved, partial, variant,
@@ -23,8 +27,41 @@ how every label is assigned.
   hypothesis = 100), assigned with a
   [published prompt](public/significance-prompt.md)
 - Community machinery: submissions with review, field-level edits with a
-  public changelog, discussion threads, votes, and member profiles - all under
-  pseudonyms only (real names, emails and avatars are never shown)
+  public changelog, discussion threads, votes, flagging, and member profiles -
+  all under pseudonyms only (real names, emails and avatars are never shown)
+
+## Frontiers
+
+Not every AI result resolves a question. Some move a number: the exponent of
+matrix multiplication, the proportion of zeta zeros proved to lie on the
+critical line, the bound on gaps between consecutive primes. A **frontier** is
+one such quantity with a direction and a dated staircase of every best known
+value, human and AI alike, so a reader can see whether a model actually moved a
+number people had been pushing for decades.
+[vibemathed.com/frontiers](https://vibemathed.com/frontiers).
+
+Frontiers are curated rather than submitted. The current best is derived from
+the rows rather than stored, so it cannot go stale when a row is added,
+retracted or re-dated.
+
+## How a submission becomes an entry
+
+Anyone signed in can submit. A curator reads the source - the paper, the
+repository, the Lean development - and either publishes the entry with its
+tiers filled in, or holds it with a written reason that lands in the
+submitter's inbox. While it waits, the queue is public at
+[vibemathed.com/queue](https://vibemathed.com/queue): titles and ages only,
+under a banner saying that nothing there is part of the record yet.
+
+When a claim ships a Lean development, the site can rebuild it instead of
+trusting a badge.
+[`.github/workflows/verify-lean.yml`](.github/workflows/verify-lean.yml) checks
+out someone else's repository at a pinned ref, installs the toolchain that
+repository names, builds every module and prints the axioms its theorems
+really use. That is what the Site-confirmed tier means here. It checks a proof
+against the statement its author wrote; whether that statement says what the
+informal problem says is a human's job, and the
+[reviewing checklist](docs/reviewing.md) says so.
 
 ## Data
 
@@ -41,9 +78,9 @@ not in git.
 
 ## Stack
 
-Next.js (App Router, v16) + TypeScript + Tailwind, CockroachDB (serverless,
-Postgres-compatible) via Prisma, Auth.js (`next-auth` v5) with Google as the
-only provider. Deployed on Vercel.
+Next.js (App Router, v16) + TypeScript + Tailwind v4, CockroachDB (serverless,
+Postgres-compatible) via Prisma, Auth.js (`next-auth` v5) with Google and
+GitHub as sign-in providers, Vitest for the unit tests. Deployed on Vercel.
 
 Cache Components (`cacheComponents: true`) is enabled, so Partial Prerendering
 is the default: each page ships a prerendered static shell, and the parts that
@@ -86,6 +123,7 @@ Open [http://localhost:3000](http://localhost:3000).
 | `npm run dev`       | Dev server                                     |
 | `npm run typecheck` | `tsc --noEmit`                                 |
 | `npm run lint`      | ESLint                                         |
+| `npm test`          | Vitest, once                                   |
 | `npm run db:push`   | Sync schema to `DATABASE_URL` (no migrations)  |
 | `npm run db:seed`   | Seed entries from `problems.json`              |
 | `npm run db:export` | Snapshot the database back to `problems.json`  |
@@ -101,11 +139,14 @@ through the site rather than through git, because the catalog lives in a
 database: see [vibemathed.com/contributing](https://vibemathed.com/contributing).
 
 For code, see [CONTRIBUTING.md](CONTRIBUTING.md). **Pull requests go to
-`main`**, which is where everything lands first; `production` is what
-vibemathed.com serves, and reaching it is a deliberate promotion. Both require
-a green CI run and one approval. [`docs/branch-flow.md`](docs/branch-flow.md)
-explains why, and lists the two migration steps still outstanding - until they
-are done, `main` is still the branch that deploys to production.
+`main`**, which is where everything lands first and which deploys to the
+staging environment. `production` is the branch vibemathed.com serves, and it
+moves only by a deliberate promotion: a pull request from `main`, merged when
+someone decides to release. Both branches require a green CI run and one
+approving review; CI runs Prisma schema validation, ESLint, `tsc`, the Vitest
+suite and a parse of the seed baseline.
+[`docs/branch-flow.md`](docs/branch-flow.md) explains why the flow is shaped
+this way and records how it was migrated.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VibeMathed
+# <img src="src/app/icon.svg" width="30" height="30" align="middle" alt=""> VibeMathed
 
 **[vibemathed.com](https://vibemathed.com)** is a community of mathematicians
 and enthusiasts tracking, curating and cataloguing the mathematical problems

--- a/scripts/audit-paren-delimiters.ts
+++ b/scripts/audit-paren-delimiters.ts
@@ -1,0 +1,64 @@
+// How many published entries use LaTeX's \( \) / \[ \] math delimiters, which
+// the site's tokenizer did not recognise before September 2026. Read-only.
+//
+// position() rather than Prisma's `contains`: LIKE treats a backslash as its
+// escape character, so `contains: "\\("` silently matches a plain "(" and
+// reports most of the catalog.
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const OPEN_PAREN = String.fromCharCode(92) + "(";
+const OPEN_BRACKET = String.fromCharCode(92) + "[";
+const FIELDS = [
+  "statement",
+  "resultNote",
+  "verificationNote",
+  "aiRole",
+  "significanceNote",
+] as const;
+
+async function connectWithRetry() {
+  for (let a = 1; a <= 6; a++) {
+    try {
+      await prisma.$queryRawUnsafe("SELECT 1");
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw new Error("database unreachable");
+}
+
+async function count(col: string, pat: string): Promise<number> {
+  const rows = await prisma.$queryRawUnsafe<{ n: number }[]>(
+    `SELECT count(*)::int AS n FROM "Problem" WHERE status = 'published' AND position($1 in coalesce("${col}", '')) > 0`,
+    pat,
+  );
+  return rows[0].n;
+}
+
+async function main() {
+  await connectWithRetry();
+  for (const [label, pat] of [
+    ["inline  \\( \\)", OPEN_PAREN],
+    ["display \\[ \\]", OPEN_BRACKET],
+  ] as const) {
+    const parts = await Promise.all(FIELDS.map((f) => count(f, pat)));
+    console.log(
+      `${label}: ` + FIELDS.map((f, i) => `${f}=${parts[i]}`).join(" "),
+    );
+  }
+  const rows = await prisma.$queryRawUnsafe<{ slug: string }[]>(
+    `SELECT slug FROM "Problem" WHERE status = 'published'
+       AND (position($1 in coalesce(statement,'')) > 0 OR position($1 in coalesce("resultNote",'')) > 0)
+     ORDER BY "createdAt" DESC LIMIT 15`,
+    OPEN_PAREN,
+  );
+  console.log(
+    `\naffected entries (newest first): ${rows.length ? rows.map((r) => r.slug).join(", ") : "none"}`,
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/review-2026-09-05-b.ts
+++ b/scripts/review-2026-09-05-b.ts
@@ -1,0 +1,231 @@
+// Second review batch of 5 September 2026: three submissions that arrived
+// during the day.
+//
+//   - Wong's MathOverflow question 235893 (connectedness-preserving bijection
+//     of R^n with a non-connectedness-preserving inverse), submitted by a new
+//     member with the MathOverflow page as Source URL and two Zenodo preprints
+//     as links. Read: both preprints in full (pypdf), the MathOverflow page
+//     including all five answers (top answer, score 40, is an explicit partial
+//     result for a map R -> R^2; the newest, 5 September, is the submitter's),
+//     and Banakh-Banakh arXiv 1809.00401 which calls the problem "still open"
+//     and poses Problems 1.7 and 1.8. The entry bundled two results; it is
+//     narrowed to Wong's question and the second is asked for as its own entry.
+//   - Latin squares, resubmitted after yesterday's disclosure-only hold. The
+//     disclosure now exists: AI_USE.md at commit ff9431c and page 19 of the
+//     paper, both read.
+//   - YAH scalar arctic first step. The note itself says the exact subquestion
+//     was not posed anywhere and the full scalar lemma is routine.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { PrismaClient } from "@prisma/client";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { MESSAGE_MAX } from "../src/lib/messages";
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes("--apply");
+const LINK_LABEL_MAX = 120;
+
+const LIMITS = new Map<string, number>();
+for (const s of [...EDITABLE_FIELDS, ...CURATOR_FIELDS])
+  if (s.maxLength) LIMITS.set(s.key, s.maxLength);
+
+type LinkIn = { label: string; url: string; kind: string };
+type Decision = {
+  slug: string;
+  action: "approve" | "reject";
+  reason: string;
+  message: string;
+  edits?: Record<string, unknown>;
+  links?: LinkIn[];
+};
+
+const DECISIONS: Decision[] = [
+  // ------------------------------------------- Wong's question, MO 235893
+  {
+    slug: "does-there-exist-a-bijection-of-mathbb-r-n-to-itself-such-that-the-forward-map-i",
+    action: "approve",
+    reason: "edited",
+    edits: {
+      shortName: "Wong's connectedness-preserving bijection",
+      sourceUrl: "https://doi.org/10.5281/zenodo.22346412",
+      sourceName:
+        "Recurrent tubes and connectedness-preserving bijections of Euclidean spaces (Zenodo preprint, 5 Sep 2026)",
+      model: "GPT-6 (Codex, Ultra effort), Claude Fable 5.1",
+      modelMaker: "OpenAI, Anthropic",
+      humanCollaborators: ["Peter L."],
+      aiContribution: "ai-discovered",
+      resolution: "candidate",
+      posedBy: "Willie Wong, MathOverflow question 235893",
+      yearPosed: 2016,
+      statement:
+        "Willie Wong asked on MathOverflow in April 2016: if $f:\\mathbb R^n\\to\\mathbb R^n$ is a bijection that maps every connected set to a connected set, must $f^{-1}$ do the same? By Tanaka's theorem and invariance of domain this is equivalent to asking whether every connectedness-preserving bijection of $\\mathbb R^n$ is continuous. For $n=1$ the answer is yes. For $n\\ge 2$ the question stayed open for a decade: the top-voted answer constructs such a bijection only from $\\mathbb R$ to $\\mathbb R^2$, and Banakh and Banakh (2020) proved continuity in several compact settings while calling Wong's problem still open.",
+      resultNote:
+        "Answered in the negative for every $n\\ge 2$. The preprint constructs a bijection $F:\\mathbb R^n\\to\\mathbb R^n$ that maps every connected set to a connected set, is continuous exactly off the closed ray $[0,\\infty)\\times\\{0\\}^{n-1}$, and pulls the straight segment $\\{(1,0,\\dots,0)\\}\\times[0,1]$ back to the middle-thirds Cantor set on that ray, so $F^{-1}$ is not connectedness-preserving. The construction extends a thin solid tube by finger moves so its cross-sections recur near every point of the complementary compactum, collapses the ray onto the tube's ideal end, and certifies arbitrary connected sets by a separation argument; $F$ and $F^{-1}$ can be taken Borel. The same author's companion note on Darboux injections from closed manifolds (Banakh-Banakh Problems 1.7 and 1.8) is a separate result and belongs in its own entry.",
+      aiRole:
+        "The preprint's own disclosure: the paper \"is the outcome of a research program conducted with two AI systems under the author's direction: OpenAI's Codex (GPT-6, Ultra effort), which produced the structural theory, the constructions, the adversarial audits, the verification of the argument, and the draft; and Anthropic's Claude Fable 5.1 (Extra effort), which planned the program, reviewed the successive run reports, and proposed the single-line coloring that makes the construction uniform in the dimension.\" The author chose the problem, wrote the briefs and ran the audits between systems. Appendix A separates ideas taken from the literature from ideas first recorded within the program.",
+      verificationNote:
+        'Unreviewed. The 17-page preprint (Zenodo 10.5281/zenodo.22346412, version 1, dated 5 September 2026) was read here on the day it appeared; the theorem, the construction outline and the disclosure match the submission. Nobody outside the author\'s program has checked the argument, and the preprint is visibly unfinished: its acknowledgements read "to be supplied by the author" and its disclosure ends with a bracketed statement "to be completed after review" that the author has verified the mathematics and accepts responsibility. Candidate until that statement is filled in and someone independent has read the proof. The question\'s history warrants care: it drew five answers over ten years, all partial, and a 2020 paper by Banakh and Banakh devoted to it.',
+      significance: 22,
+      significanceNote:
+        "A MathOverflow question open since 2016 with a real following: a score of 40 on the top partial answer, a 2020 arXiv paper by Banakh and Banakh built around it, and its own name in the literature (Darboux bijections of R^n). A clean negative answer to a decade-old question in general topology, one rung above the numbered-Erdős level; well below structural conjectures, since it settles one question rather than a programme.",
+    },
+    links: [
+      {
+        label:
+          "Wong's question on MathOverflow (2016), with the five partial answers",
+        url: "https://mathoverflow.net/questions/235893",
+        kind: "problem-record",
+      },
+      {
+        label:
+          "Banakh and Banakh, The continuity of Darboux injections between manifolds (2020), which calls the problem still open",
+        url: "https://arxiv.org/abs/1809.00401",
+        kind: "paper",
+      },
+    ],
+    message:
+      "Published, at Candidate and Unreviewed, with the Source URL corrected as you asked on Discord and the entry narrowed to one question. Nothing needs resubmitting for this one.\n\nSource URL now points at the preprint (Zenodo 22346412), which is the thing under review; the MathOverflow page moved to a problem-record link. Both DOIs you gave resolve to the versioned records already attached, so nothing was lost.\n\nThe entry bundled two results, and this site lists one question per entry: Wong's question is answered by the tubes preprint, and Banakh-Banakh Problems 1.7 and 1.8 are answered by the Darboux-injections note with a different model (GPT-5.5 Pro). This entry is now Wong's question only. Please submit the Banakh-Banakh result as its own entry with the Darboux note as Source URL; it is a real answer to two posed problems and should take minutes to review, since I have already read the paper.\n\nWhat I checked: both preprints in full, the MathOverflow page with all five answers (the top one, score 40, is a partial result for a map from the line to the plane; yours is the fifth), and Banakh and Banakh's 2020 paper, which poses 1.7 and 1.8 and calls Wong's problem still open. So the question was open and the claim is what you say it is.\n\nCandidate rather than Resolved for two reasons a reader can see for themselves. The preprint is dated today and nobody outside the program has read it. And it is visibly unfinished: the acknowledgements say \"to be supplied by the author\" and the disclosure ends with a bracketed statement, to be completed after review, that the author has verified the mathematics and takes responsibility. Fill that in, and the moment someone independent has read the argument, this moves to Resolved.\n\nModel field normalised to what the paper says: GPT-6 via Codex at Ultra effort, and Claude Fable 5.1. Significance 22.",
+  },
+
+  // ------------------------------------------- Latin squares, resubmitted
+  {
+    slug: "parity-obstruction-in-the-minimum-determinant-problem-for-latin-squares-2",
+    action: "approve",
+    reason: "edited",
+    edits: {
+      significance: 10,
+      significanceNote:
+        "A 2014 Mathematics Stack Exchange question about when the divisibility lower bound for Latin-square determinants is attained, with a conjecture that only orders 4 and 6 fail. This is partial progress: an exact parity criterion and a family with odd quotient for every n = 2 mod 4, removing one obstruction without settling attainment. A precise question with a small literature, at the numbered-Erdős level.",
+    },
+    message:
+      "Published, at Partial and Unreviewed as you set them, at significance 10.\n\nYesterday's hold was on one ground and you fixed it: at commit ff9431c the repository carries AI_USE.md and the paper carries the same statement on page 19, naming GPT-5.4 and saying exactly what it did and what you did. That is what the site needs and it is now the model for how to do it.\n\nThe distinctions you asked to preserve are preserved: the entry says odd quotient, not quotient of absolute value one; it says partial, not resolution; and it credits the baseline divisor to the literature. The mathematics was never in question and I have not re-reviewed it; the certified datasets and the passing verifier are as described.\n\nSignificance 10: a precise 2014 question with a conjecture attached and partial progress toward it.",
+  },
+
+  // ----------------------------------------------- YAH scalar arctic step
+  {
+    slug: "yah-mixed-base-collatz-system-scalar-arctic-first-step-obstruction",
+    action: "reject",
+    reason: "no-open-question",
+    message:
+      "Declined, on the ground you anticipated in your note, and with respect for how carefully you framed it.\n\nThis site lists results that settle, or make measurable progress on, a question somebody posed before the work began. Your own scope statement says the exact scalar subquestion was not separately posed in Yolcu, Aaronson and Heule, that the full scalar lemma is routine, and that the contribution is the combined top/labelled certificate package, whose novelty you could not establish beyond a bounded search. Section 6 of YAH raises a direction, not a question with a yes or no; a restriction of a direction that the authors of the restriction chose themselves is not something the catalog can hold, however sound the certificates are.\n\nWhat would qualify, from the same programme: a result on the question YAH actually leave open, whether matrix interpretations of any dimension can prove termination of the mixed-base system, in either direction; or a reframing where a named, previously stated conjecture or problem is the target. If you get there, submit it and cite this note as prior work.\n\nThe replayable certificates, the honest attribution note and the explicit non-claims are all in the right spirit. It is the shape of the question, not the quality of the work, that keeps it out.",
+  },
+];
+
+async function main() {
+  const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+    "SELECT current_database() AS db",
+  );
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const curator = await prisma.user.findFirst({
+    where: { pseudonym: "Rasmus Lindahl" },
+    select: { id: true, pseudonym: true },
+  });
+
+  let bad = 0;
+  for (const d of DECISIONS) {
+    const cur = await prisma.problem.findUnique({
+      where: { slug: d.slug },
+      select: { id: true, status: true, name: true },
+    });
+    if (!cur) throw new Error(`not found on ${db}: ${d.slug}`);
+    if (cur.status !== "pending")
+      throw new Error(`${d.slug} is ${cur.status}, not pending`);
+
+    console.log(
+      `${d.action === "reject" ? "REJECT " : "APPROVE"}  ${cur.name.slice(0, 58)}  [${d.reason}]`,
+    );
+    console.log(
+      `  message : ${d.message.length}/${MESSAGE_MAX}${d.message.length > MESSAGE_MAX ? "  OVER" : ""}`,
+    );
+    if (d.message.length > MESSAGE_MAX) bad++;
+    for (const [k, v] of Object.entries(d.edits ?? {})) {
+      const lim = LIMITS.get(k);
+      if (typeof v === "string" && lim) {
+        const over = v.length > lim;
+        console.log(
+          `  ${k.padEnd(17)}: ${v.length}/${lim}${over ? `  OVER BY ${v.length - lim}` : ""}`,
+        );
+        if (over) bad++;
+      } else {
+        console.log(`  ${k.padEnd(17)}: ${JSON.stringify(v).slice(0, 70)}`);
+      }
+    }
+    for (const l of d.links ?? []) {
+      console.log(
+        `  link             : ${l.label.length}/${LINK_LABEL_MAX}  ${l.kind}`,
+      );
+      if (l.label.length > LINK_LABEL_MAX) bad++;
+    }
+  }
+  if (bad) throw new Error(`${bad} limit violation(s)`);
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+  if (!curator) throw new Error("curator not found on this database");
+
+  for (const d of DECISIONS) {
+    const cur = await prisma.problem.findUnique({
+      where: { slug: d.slug },
+      select: {
+        id: true,
+        submittedById: true,
+        _count: { select: { links: true } },
+      },
+    });
+    if (!cur) throw new Error(`vanished: ${d.slug}`);
+    const n = cur._count.links;
+
+    await prisma.$transaction([
+      prisma.problem.update({
+        where: { id: cur.id },
+        data: {
+          ...(d.edits ?? {}),
+          ...(d.links?.length
+            ? {
+                links: {
+                  create: d.links.map((l, i) => ({ ...l, position: n + i })),
+                },
+              }
+            : {}),
+          status: d.action === "approve" ? "published" : "rejected",
+          reviewedAt: new Date(),
+          reviewMessage: d.message,
+          reviewReason: d.reason,
+        } as never,
+      }),
+      prisma.directMessage.create({
+        data: {
+          userId: cur.submittedById!,
+          senderId: curator.id,
+          senderName: curator.pseudonym,
+          kind: "decision",
+          reason: d.reason,
+          body: d.message.slice(0, MESSAGE_MAX),
+          problemId: cur.id,
+        },
+      }),
+      prisma.problemActivity.create({
+        data: {
+          problemId: cur.id,
+          userId: curator.id,
+          userName: curator.pseudonym,
+          type: d.action === "approve" ? "approved" : "rejected",
+        },
+      }),
+    ]);
+    console.log(`applied: ${d.action} ${d.slug}`);
+  }
+
+  console.log(
+    "\nAPPLIED. Public caches lag until the next deploy; entry pages are right immediately.",
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/src/components/TeX.tsx
+++ b/src/components/TeX.tsx
@@ -124,6 +124,12 @@ export function deTeX(s: string): string {
   // not pair with a real delimiter and swallow the sentence between them. A meta
   // description gets this wrong silently, which is how it went unnoticed.
   let out = s.replace(/(?<!\\)\$\$?((?:\\.|[^$\\])+)\$\$?/g, "$1");
+  // The other pair of delimiters the tokenizer accepts, `\(…\)` and `\[…\]`.
+  // Without this a meta description carries the backslashes into the search
+  // result, and the catch-all below deletes only commands made of letters, so
+  // they would survive it.
+  out = out.replace(/\\\[[\s\S]*?\\\]/g, (m) => m.slice(2, -2));
+  out = out.replace(/\\\([\s\S]*?\\\)/g, (m) => m.slice(2, -2));
   for (const [re, rep] of REPLACEMENTS) out = out.replace(re, rep);
   out = unescapeDollars(out);
   return (

--- a/src/lib/comment-render.ts
+++ b/src/lib/comment-render.ts
@@ -13,7 +13,13 @@
 
 import katex from "katex";
 import { linkifyEscaped } from "@/lib/linkify";
-import { TEX_TOKENS, isDisplayMath, isInlineMath, unescapeDollars } from "@/lib/tex-tokens";
+import {
+  TEX_TOKENS,
+  isDisplayMath,
+  isInlineMath,
+  mathBody,
+  unescapeDollars,
+} from "@/lib/tex-tokens";
 
 function escapeHtml(s: string): string {
   return s
@@ -24,7 +30,10 @@ function escapeHtml(s: string): string {
 }
 
 function renderMath(tex: string, display: boolean): string {
-  return katex.renderToString(tex, { throwOnError: false, displayMode: display });
+  return katex.renderToString(tex, {
+    throwOnError: false,
+    displayMode: display,
+  });
 }
 
 /// Plain text in, safe HTML out. Blank lines separate paragraphs; single
@@ -36,8 +45,8 @@ export function renderCommentHtml(text: string): string {
       const parts = paragraph.split(TEX_TOKENS);
       const inner = parts
         .map((part) => {
-          if (isDisplayMath(part)) return renderMath(part.slice(2, -2), true);
-          if (isInlineMath(part)) return renderMath(part.slice(1, -1), false);
+          if (isDisplayMath(part)) return renderMath(mathBody(part), true);
+          if (isInlineMath(part)) return renderMath(mathBody(part), false);
           const linked = linkifyEscaped(escapeHtml(part));
           return unescapeDollars(linked).replace(/\n/g, "<br />");
         })
@@ -52,8 +61,18 @@ export function renderCommentHtml(text: string): string {
 export function formatCommentDate(d: Date): string {
   const day = String(d.getUTCDate()).padStart(2, "0");
   const months = [
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
   ];
   return `${day} ${months[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
 }

--- a/src/lib/tex-render.ts
+++ b/src/lib/tex-render.ts
@@ -1,5 +1,11 @@
 import { linkifyEscaped } from "@/lib/linkify";
-import { TEX_TOKENS, isDisplayMath, isInlineMath, unescapeDollars } from "@/lib/tex-tokens";
+import {
+  TEX_TOKENS,
+  isDisplayMath,
+  isInlineMath,
+  mathBody,
+  unescapeDollars,
+} from "@/lib/tex-tokens";
 
 export type MathRenderer = (tex: string, display: boolean) => string;
 
@@ -21,8 +27,8 @@ export function renderTexToHtml(
   const parts = children.split(TEX_TOKENS);
   return parts
     .map((part, i) => {
-      if (isDisplayMath(part)) return renderMath(part.slice(2, -2), true);
-      if (isInlineMath(part)) return renderMath(part.slice(1, -1), false);
+      if (isDisplayMath(part)) return renderMath(mathBody(part), true);
+      if (isInlineMath(part)) return renderMath(mathBody(part), false);
 
       // Display math is already a block, so discard a newline touching it
       // rather than rendering a duplicate gap.

--- a/src/lib/tex-tokens.test.ts
+++ b/src/lib/tex-tokens.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { TEX_TOKENS, isDisplayMath, isInlineMath, unescapeDollars } from "@/lib/tex-tokens";
+import {
+  TEX_TOKENS,
+  isDisplayMath,
+  isInlineMath,
+  mathBody,
+  unescapeDollars,
+} from "@/lib/tex-tokens";
 import { deTeX, texToHtml } from "@/components/TeX";
 
 // The tokenizer is shared by the entry renderer, the comment renderer and the
@@ -21,6 +27,60 @@ describe("TEX_TOKENS", () => {
     const parts = split("Then $$\\sum_{k\\ge1} a_k$$ converges.");
     expect(parts.filter(isDisplayMath)).toEqual(["$$\\sum_{k\\ge1} a_k$$"]);
     expect(parts.filter(isInlineMath)).toEqual([]);
+  });
+
+  // LaTeX's other delimiters, added September 2026. The 19-dimensional
+  // kissing entry published with its whole statement as literal backslashes
+  // because nothing here matched them.
+  it("splits LaTeX's paren delimiters out of prose", () => {
+    const parts = split("Let \\(D\\subseteq\\mathbb F_2^{19}\\) be the code.");
+    expect(parts.filter(isInlineMath)).toEqual([
+      "\\(D\\subseteq\\mathbb F_2^{19}\\)",
+    ]);
+    expect(parts.filter(isDisplayMath)).toEqual([]);
+  });
+
+  it("splits LaTeX's bracket delimiters as display math", () => {
+    const parts = split("Then \\[\\sum_{k\\ge1} a_k\\] converges.");
+    expect(parts.filter(isDisplayMath)).toEqual(["\\[\\sum_{k\\ge1} a_k\\]"]);
+    expect(parts.filter(isInlineMath)).toEqual([]);
+  });
+
+  it("stops each paren segment at its OWN closing delimiter", () => {
+    // The trap: an escape-aware body would eat "\)" as an escape pair and run
+    // the first segment on to the last one in the field.
+    const parts = split("both \\(a\\) and \\(b\\) hold");
+    expect(parts.filter(isInlineMath)).toEqual(["\\(a\\)", "\\(b\\)"]);
+    expect(parts.filter((p) => !isInlineMath(p) && p)).toEqual([
+      "both ",
+      " and ",
+      " hold",
+    ]);
+  });
+
+  it("mathBody strips whichever delimiters were used", () => {
+    expect(mathBody("$x^2$")).toBe("x^2");
+    expect(mathBody("$$x^2$$")).toBe("x^2");
+    expect(mathBody("\\(x^2\\)")).toBe("x^2");
+    expect(mathBody("\\[x^2\\]")).toBe("x^2");
+  });
+
+  it("renders the paren forms as math rather than as prose", () => {
+    const html = texToHtml("Let \\(A\\subseteq D\\) be admissible.");
+    // Exactly one formula, and the delimiters are gone from the prose. The raw
+    // TeX still appears inside KaTeX's own MathML annotation, which is why
+    // this counts spans instead of grepping for the command.
+    expect(html.match(/class="katex"/g)?.length ?? 0).toBe(1);
+    expect(html).toContain("Let ");
+    expect(html).toContain(" be admissible.");
+    expect(html).not.toContain("katex-error");
+  });
+
+  it("deTeX drops the paren delimiters", () => {
+    // Spacing is the author's: "A\subseteq D" has no space before the command,
+    // and deTeX substitutes rather than reflows, exactly as for the $ forms.
+    expect(deTeX("Let \\(A\\subseteq D\\) hold")).toBe("Let A⊆ D hold");
+    expect(deTeX("Then \\[x + y\\] follows")).toBe("Then x + y follows");
   });
 
   it("does not treat an escaped dollar as a delimiter", () => {
@@ -78,7 +138,9 @@ describe("deTeX", () => {
   });
 
   it("keeps an escaped dollar as a literal dollar", () => {
-    expect(deTeX("a \\$10,000 prize for $n^2$")).toBe("a $10,000 prize for n^2");
+    expect(deTeX("a \\$10,000 prize for $n^2$")).toBe(
+      "a $10,000 prize for n^2",
+    );
   });
 
   it("flattens newlines for a meta tag", () => {

--- a/src/lib/tex-tokens.ts
+++ b/src/lib/tex-tokens.ts
@@ -21,15 +21,45 @@
 // backslash immediately before real math still mis-parses, because the
 // lookbehind cannot tell an escaped backslash from an escaping one. That costs a
 // regex several times this size to fix and has never occurred in the catalog.
+//
+// LaTeX's OTHER delimiters, `\(…\)` and `\[…\]`, are accepted too, since
+// September 2026. They are what someone who writes papers types, KaTeX's own
+// auto-render accepts them by default, and a submitter used them: the
+// 19-dimensional kissing entry published with its whole statement as literal
+// backslashes on screen, because nothing matched and the text fell through to
+// be escaped as prose. The site takes submissions from anyone, so this was
+// going to recur.
+//
+// These two use a lazy any-character run to the first closing delimiter
+// rather than the escape-aware body the dollar forms use. `(?:\\.|[^$\\])+`
+// would let `\)` be eaten as an escape pair and run the segment on to the
+// LAST `\)` in the field. Inside real math nobody writes `\)` for anything
+// but closing, so first-match is the right reading.
 export const TEX_TOKENS =
-  /((?<!\\)\$\$(?:\\.|[^$\\])+\$\$|(?<!\\)\$(?:\\.|[^$\\])+\$)/g;
+  /((?<!\\)\$\$(?:\\.|[^$\\])+\$\$|(?<!\\)\$(?:\\.|[^$\\])+\$|\\\[[\s\S]*?\\\]|\\\([\s\S]*?\\\))/g;
 
 export function isDisplayMath(part: string): boolean {
-  return part.startsWith("$$") && part.endsWith("$$") && part.length > 4;
+  return (
+    (part.startsWith("$$") && part.endsWith("$$") && part.length > 4) ||
+    (part.startsWith("\\[") && part.endsWith("\\]") && part.length > 4)
+  );
 }
 
 export function isInlineMath(part: string): boolean {
-  return !isDisplayMath(part) && part.startsWith("$") && part.endsWith("$") && part.length > 2;
+  if (isDisplayMath(part)) return false;
+  return (
+    (part.startsWith("$") && part.endsWith("$") && part.length > 2) ||
+    (part.startsWith("\\(") && part.endsWith("\\)") && part.length > 4)
+  );
+}
+
+/// The TeX inside a math segment, with whichever delimiters it arrived in
+/// removed. Shared because the two renderers used to slice by hand, and a
+/// hand-written `slice(1, -1)` is wrong the moment a two-character delimiter
+/// exists.
+export function mathBody(part: string): string {
+  if (part.startsWith("$") && !part.startsWith("$$")) return part.slice(1, -1);
+  return part.slice(2, -2);
 }
 
 /// Turns an author's `\$` into a literal dollar.


### PR DESCRIPTION
Release PR under `docs/branch-flow.md`. No database step: the schema is unchanged between `production` and `main`.

## What it carries

- #46 Accept LaTeX's `\(…\)` and `\[…\]` math delimiters. The 19-dimensional kissing entry currently shows its whole statement as literal backslashes; this is the fix, and the entry needs no data edit.
- #45 README and CONTRIBUTING brought up to date: three factual errors (Google-only sign-in, a finished migration described as outstanding, missing `npm test`), plus Frontiers, the review flow and `verify-lean.yml` documented, and CONTRIBUTING's contradictory staging diagram removed.

## Verify on vibemathed.com after deploy

- `/problem/optimality-of-the-added-vector-code-in-the-19-dimensional-kissing-construction` renders its statement as mathematics, not backslashes
- an entry using `$…$` still renders unchanged (for example `/problem/kothe-conjecture`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wddi3MgHAsjbw3w9B18cn8