### PR TITLE
Release: frontier social cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 <!-- BEGIN:nextjs-agent-rules -->
+
 # This is NOT the Next.js you know
 
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
 <!-- END:nextjs-agent-rules -->

--- a/src/app/frontier/[slug]/opengraph-image.tsx
+++ b/src/app/frontier/[slug]/opengraph-image.tsx
@@ -1,0 +1,173 @@
+import { ImageResponse } from "next/og";
+import { getFrontierBySlug } from "@/lib/data";
+import { bestRow, competes, steps } from "@/lib/frontiers";
+import { deTeX } from "@/components/TeX";
+import { cardText, clip } from "@/lib/card-text";
+import { SITE_URL } from "@/lib/site";
+
+// Per-frontier share card.
+//
+// Same reason the entry card exists: without a file here the route has NO
+// image, the root card does not cascade in practice, and X renders a
+// summary_large_image with a grey placeholder - which is what every shared
+// frontier link looked like from the day the feature launched until this
+// landed.
+//
+// What a frontier link IS differs from an entry: not "which problem and was it
+// proved" but "which quantity, where does it stand, and who moved it last".
+// So the middle band carries the current best VALUE at display size, with the
+// frontier's name above it and the attribution below. A reader who sees the
+// card in a timeline should learn the number without opening the page.
+//
+// Satori-safe, the same three rules the entry card records: flexbox only,
+// default font, the mark as a data-URI <img> rather than an inline <svg>.
+
+const MARK = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="7" fill="#2a78d6"/><path d="M4 16 C 7 9, 11 9, 16 16 C 21 23, 25 23, 28 16" fill="none" stroke="#f3efe3" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+const MARK_URI = `data:image/svg+xml;base64,${Buffer.from(MARK).toString("base64")}`;
+const DOMAIN = SITE_URL.replace(/^https?:\/\//, "").replace(/\/$/, "");
+
+export const alt = "VibeMathed frontier card";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function OpengraphImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  // A missing frontier, or a database that blinks, still has to produce an
+  // image. A throw here is a 500, and a scraper caches that 500 for as long as
+  // it likes - the grey placeholder this file exists to remove, made permanent
+  // by a blip. The generic card is a much better failure.
+  const f = await getFrontierBySlug(slug).catch(() => null);
+
+  const name = f ? cardText(deTeX(f.shortName || f.name)) : "Frontiers";
+  const title = name.length > 70 ? `${name.slice(0, 69)}…` : name;
+
+  const best = f ? bestRow(f.rows, f.direction) : null;
+  // The compact form when a curator wrote one: these are the same values the
+  // landing strip shows, and the long form of a bound is a paragraph.
+  const value = best
+    ? cardText(deTeX(best.valueShortTex ?? best.valueTex))
+    : "";
+  // A bound like "≫ log X log_2 X / log_4 X" needs to step down or it runs off
+  // the canvas; a bare number gets the full display size.
+  const valueSize =
+    value.length > 26 ? "68px" : value.length > 14 ? "96px" : "132px";
+
+  // A nine-author list plus the model's name runs past the canvas. Cut on a
+  // word boundary, not mid-name: slicing at a fixed length produced
+  // "... Thorner and Xie (Axio," on the first render of this card.
+  const attribution = best ? clip(cardText(deTeX(best.attribution)), 58) : "";
+
+  const stepped = f ? steps(f.rows, f.direction) : [];
+  const nSteps = stepped.filter((s) => s.isStep).length;
+  const nAi = stepped.filter((s) => s.isStep && s.row.entry).length;
+  const first = f
+    ? f.rows
+        .filter((r) => competes(r.status))
+        .map((r) => r.date)
+        .sort()[0]
+    : undefined;
+
+  const footer = [
+    f?.fieldGroup,
+    nSteps ? `${nSteps} steps, ${nAi} by AI` : null,
+    first ? `since ${first.slice(0, 4)}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        background: "#f3efe3",
+        color: "#201d17",
+        padding: "72px 80px",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "20px" }}>
+        {/* eslint-disable-next-line @next/next/no-img-element -- Satori
+              renders a plain img; next/image does not exist in this runtime. */}
+        <img src={MARK_URI} width={56} height={56} alt="" />
+        <div style={{ display: "flex", fontSize: "32px", color: "#5c5648" }}>
+          {DOMAIN}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: "24px",
+            color: "#a8622a",
+            border: "2px solid #a8622a",
+            borderRadius: "6px",
+            padding: "3px 14px",
+            letterSpacing: "2px",
+          }}
+        >
+          FRONTIER
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "18px" }}>
+        <div
+          style={{
+            display: "flex",
+            fontSize: "40px",
+            color: "#5c5648",
+            lineHeight: 1.15,
+          }}
+        >
+          {title}
+        </div>
+        {value && (
+          <div
+            style={{
+              display: "flex",
+              fontSize: valueSize,
+              fontWeight: 700,
+              letterSpacing: "-2px",
+              lineHeight: 1.05,
+            }}
+          >
+            {value}
+          </div>
+        )}
+        {best && (
+          <div style={{ display: "flex", fontSize: "30px", color: "#5c5648" }}>
+            {attribution} · {best.date}
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontSize: "28px",
+          color: "#8a8271",
+        }}
+      >
+        <div style={{ display: "flex" }}>
+          {footer ||
+            (!f
+              ? "Quantities AI has moved"
+              : f.direction === "min"
+                ? "lower is better"
+                : "higher is better")}
+        </div>
+        <div style={{ display: "flex" }}>
+          <span style={{ color: "#201d17", fontWeight: 700 }}>Vibe</span>
+          <span style={{ color: "#2a78d6", fontWeight: 700 }}>Mathed</span>
+        </div>
+      </div>
+    </div>,
+    { ...size },
+  );
+}

--- a/src/app/frontiers/opengraph-image.tsx
+++ b/src/app/frontiers/opengraph-image.tsx
@@ -1,0 +1,104 @@
+import { ImageResponse } from "next/og";
+import { getFrontiers } from "@/lib/data";
+import { steps } from "@/lib/frontiers";
+import { SITE_URL } from "@/lib/site";
+
+// The frontiers index card. Same reason as the per-frontier one: the root
+// card does not cascade, so without this file the section's own link shares as
+// a grey placeholder - and the index is the link an announcement uses.
+//
+// It counts rather than lists. Naming three frontiers would date the card the
+// moment a fourth interesting one lands, and the count plus the sentence is
+// what a reader needs to decide whether to click.
+//
+// Satori-safe: flexbox only, default font, the mark as a data-URI <img>.
+
+const MARK = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="7" fill="#2a78d6"/><path d="M4 16 C 7 9, 11 9, 16 16 C 21 23, 25 23, 28 16" fill="none" stroke="#f3efe3" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+const MARK_URI = `data:image/svg+xml;base64,${Buffer.from(MARK).toString("base64")}`;
+const DOMAIN = SITE_URL.replace(/^https?:\/\//, "").replace(/\/$/, "");
+
+export const alt = "VibeMathed frontiers: quantities AI has moved";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function OpengraphImage() {
+  // Never throw: a 500 here is a grey placeholder that a scraper may cache for
+  // days, which is the exact failure this file exists to remove. An empty list
+  // just drops the count line.
+  const frontiers = await getFrontiers().catch(() => []);
+  const nAi = frontiers.reduce(
+    (n, f) =>
+      n +
+      steps(f.rows, f.direction).filter((s) => s.isStep && s.row.entry).length,
+    0,
+  );
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        background: "#f3efe3",
+        color: "#201d17",
+        padding: "72px 80px",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "20px" }}>
+        {/* eslint-disable-next-line @next/next/no-img-element -- Satori
+              renders a plain img; next/image does not exist in this runtime. */}
+        <img src={MARK_URI} width={56} height={56} alt="" />
+        <div style={{ display: "flex", fontSize: "32px", color: "#5c5648" }}>
+          {DOMAIN}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "22px" }}>
+        <div
+          style={{
+            display: "flex",
+            fontSize: "112px",
+            fontWeight: 700,
+            letterSpacing: "-4px",
+          }}
+        >
+          Frontiers
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: "40px",
+            color: "#5c5648",
+            lineHeight: 1.25,
+          }}
+        >
+          Quantities mathematicians have pushed for decades, and where AI has
+          moved them.
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          fontSize: "28px",
+          color: "#8a8271",
+        }}
+      >
+        <div style={{ display: "flex" }}>
+          {frontiers.length
+            ? `${frontiers.length} tracked${nAi ? ` · ${nAi} steps by AI` : ""}`
+            : "A community-curated catalog"}
+        </div>
+        <div style={{ display: "flex" }}>
+          <span style={{ color: "#201d17", fontWeight: 700 }}>Vibe</span>
+          <span style={{ color: "#2a78d6", fontWeight: 700 }}>Mathed</span>
+        </div>
+      </div>
+    </div>,
+    { ...size },
+  );
+}

--- a/src/lib/card-text.test.ts
+++ b/src/lib/card-text.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { cardText, clip } from "@/lib/card-text";
+import { deTeX } from "@/components/TeX";
+
+// These two helpers exist because of two defects seen on real cards, and the
+// tests below are those defects.
+
+describe("cardText", () => {
+  it("replaces the glyphs next/og cannot draw", () => {
+    // The long-prime-gaps card rendered a tofu box here. next/og named the set
+    // itself: Failed to load dynamic font for "≫≪⊆⊂∈".
+    expect(cardText("≫ log X")).toBe(">> log X");
+    expect(cardText("≪ 1")).toBe("<< 1");
+    for (const c of "≫≪⊆⊂⊇⊃∈∉≅") {
+      expect(cardText(c)).not.toContain(c);
+    }
+  });
+
+  it("leaves the glyphs the font does have", () => {
+    // Substituting these would be a regression in the other direction: they
+    // render, and ASCII stand-ins read worse.
+    const safe = "≤ ≥ ≠ ≈ ∞ ∑ ∏ ∫ √ α π Ω · … → × ÷ ±";
+    expect(cardText(safe)).toBe(safe);
+  });
+
+  it("lifts sub- and superscript digits out of TeX source", () => {
+    expect(cardText("(log_2 X)^2")).toBe("(log₂ X)²");
+    expect(cardText("x^{10}")).toBe("x¹⁰");
+    expect(cardText("a_{12}")).toBe("a₁₂");
+  });
+
+  it("handles the whole long-prime-gaps bound end to end", () => {
+    // The exact value that first exposed both problems, taken through the same
+    // path the card uses.
+    const out = cardText(
+      deTeX("$\\gg \\log X (\\log_2 X)^2 \\log_4 X / (\\log_3 X)^2$"),
+    );
+    expect(out).toContain(">>");
+    expect(out).toContain("log₂");
+    expect(out).toContain(")²");
+    expect(out).not.toContain("^");
+    expect(out).not.toContain("_");
+  });
+
+  it("leaves a plain number alone", () => {
+    expect(cardText("2.371177")).toBe("2.371177");
+    expect(cardText("> 67.25%")).toBe("> 67.25%");
+  });
+});
+
+describe("clip", () => {
+  it("returns a short string untouched", () => {
+    expect(clip("GPT 6 Astra", 58)).toBe("GPT 6 Astra");
+  });
+
+  it("cuts on a word boundary, not mid-name", () => {
+    // The bounded-prime-gaps card shipped "... Thorner and Xie (Axio," before
+    // this existed.
+    const long =
+      "Charton, Hong, Lau, Ono, Remy, Siu, Swaminathan, Thorner and Xie (Axiom)";
+    const out = clip(long, 58);
+    expect(out.length).toBeLessThanOrEqual(59);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out).not.toContain("(Axio");
+    // Whatever survives is whole words of the original.
+    expect(long.startsWith(out.slice(0, -1))).toBe(true);
+  });
+
+  it("drops a dangling separator before the ellipsis", () => {
+    expect(clip("Alice, Bob, Carol, Dave", 12)).toBe("Alice, Bob…");
+  });
+
+  it("hard-cuts a single token with no space to break on", () => {
+    expect(clip("a".repeat(80), 20)).toBe(`${"a".repeat(20)}…`);
+  });
+});

--- a/src/lib/card-text.ts
+++ b/src/lib/card-text.ts
@@ -1,0 +1,70 @@
+// Text preparation for the OpenGraph cards, which are rendered by Satori and
+// so have neither KaTeX nor a full font behind them.
+//
+// This lives in lib/ rather than inside the route because the glyph list below
+// is a measured fact about next/og that will go stale, and a stale fact needs
+// a test holding it.
+
+// next/og bundles a Noto Sans subset. A glyph missing from it does NOT fall
+// back to another face: next/og tries to fetch a font that has it and, when
+// that fails, draws a tofu box. That is how the long-prime-gaps card first
+// rendered its "much greater than" - the server log read
+//   Failed to load dynamic font for "≫≪⊆⊂∈". Status: 400
+// naming the exact set below.
+//
+// A probe card rendered in September 2026 fixed the boundary. Present and safe
+// to emit: the Greek alphabet, ≤ ≥ ≠ ≈ ∞, the big operators ∑ ∏ ∫ √,
+// · … → × ÷ ±, and superscript digits. Subscript digits render at full size
+// rather than small, which is a blemish and not a box, so they stay.
+//
+// Re-run that probe before trusting this list against a newer next/og.
+const TOFU: Record<string, string> = {
+  "≫": ">>",
+  "≪": "<<",
+  "≳": ">~",
+  "≲": "<~",
+  "⊆": "⊂=",
+  "⊂": "in",
+  "⊇": "=⊃",
+  "⊃": "contains",
+  "∈": "in",
+  "∉": "not in",
+  "≅": "~=",
+};
+
+const SUP = "⁰¹²³⁴⁵⁶⁷⁸⁹";
+const SUB = "₀₁₂₃₄₅₆₇₈₉";
+
+/**
+ * Make a string safe and legible on a Satori-rendered card.
+ *
+ * deTeX leaves "x^2" and "log_2" as source, because on a page KaTeX sets them.
+ * On a card there is no KaTeX, so a raw caret reads as code rather than as
+ * mathematics; lift the digits instead. Then swap anything the bundled font
+ * cannot draw for an ASCII stand-in.
+ */
+export function cardText(s: string): string {
+  return s
+    .replace(/\^\{?(\d+)\}?/g, (_, d: string) =>
+      [...d].map((c) => SUP[Number(c)]).join(""),
+    )
+    .replace(/_\{?(\d+)\}?/g, (_, d: string) =>
+      [...d].map((c) => SUB[Number(c)]).join(""),
+    )
+    .replace(/[≫≪≳≲⊆⊂⊇⊃∈∉≅]/g, (c) => TOFU[c] ?? c);
+}
+
+/**
+ * Shorten to fit one line, cutting on a word boundary.
+ *
+ * A nine-author attribution plus the model's name runs past the canvas. A
+ * fixed-length slice cuts mid-name: the first render of the bounded-prime-gaps
+ * card ended "... Thorner and Xie (Axio,". Falls back to a hard cut when the
+ * tail holds no space at all, so a single very long token still shortens.
+ */
+export function clip(s: string, n: number): string {
+  if (s.length <= n) return s;
+  const cut = s.slice(0, n);
+  const at = cut.lastIndexOf(" ");
+  return `${(at > n / 2 ? cut.slice(0, at) : cut).replace(/[,;:]$/, "")}…`;
+}


### PR DESCRIPTION
Release of #48: OpenGraph social cards for `/frontiers` and `/frontier/[slug]`.

Until now the root card did not cascade to these routes, so every frontier link shared on X or Discord since the feature launched rendered as a bare URL with a grey placeholder. The Frontiers announcement link included.

## What lands

- **`/frontier/[slug]`** - the current best value at display size, with the frontier name above and the attribution below, plus a footer of field, step count, how many of those steps were AI, and the year the frontier starts.
- **`/frontiers`** - counts rather than lists, so a fourth interesting frontier does not date it.
- **`src/lib/card-text.ts`** with 9 tests: the glyph map for what next/og's bundled font cannot draw, sub- and superscript lifting, and word-boundary clipping for long attributions.

## Verified on the preview deployment

Not only locally - the tofu-glyph fix depends on next/og's font-fetch behaviour at runtime, so it had to be confirmed on Vercel. It was: `frontier/long-prime-gaps/opengraph-image` renders `>> log X (log₂ X)² log₄ X / (log₃ X)²` with no boxes, on one line.

Both OG routes returned 200 from the preview, and both pages emit `og:image` pointing at them with `twitter:card: summary_large_image`.

## After this deploys

Paste a `/frontier/<slug>` URL and the `/frontiers` URL into a Discord message or the X card validator and confirm a card renders. Worth doing promptly - a scraper that has already cached the placeholder may need the validator to refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wddi3MgHAsjbw3w9B18cn8
