### PR TITLE
Typeset the percolation entry's mathematics

### DIFF
--- a/scripts/credit-leder-2026-09-08.ts
+++ b/scripts/credit-leder-2026-09-08.ts
@@ -1,0 +1,162 @@
+// Replaces the submitter's paraphrase of the AI role on the percolation entry
+// with the repository's own words, and records the disclosed wall time.
+//
+// This started as "credit the directing human", which turned out to be
+// unnecessary: humanCollaborators already reads ["Justin Leder"], supplied by
+// the submitter. What is left is precision of attribution rather than the
+// presence of it.
+//
+// The name and the role were checked against three first-party places in
+// anthropics/formal-math at the pinned commit rather than taken from the
+// submitter, who is an anonymous account:
+//
+//   NOTICE            "Responsible author and maintainer: Justin Leder. The
+//                     Lean sources in this repository were written by an AI
+//                     system (Anthropic's Claude models) working autonomously
+//                     under his direction."
+//   README.md         "Author. Justin Leder (@jleder3)."
+//   formalization.yaml the human-role and prompting-notes blocks quoted below.
+//
+// Also adds the repository's own guide to the proof as a link. Its README
+// calls summary.pdf "the guide to the proof" and warns that the library
+// docstrings "were machine-written as working notes... they are not an
+// exposition", so pointing a reader at the summary rather than at the sources
+// is the useful thing to do.
+//
+// ageNote records the wall time, because a problem open since 1960 in the hard
+// dimensions and closed in about a week of compute is the fact a reader will
+// want, and it is disclosed in the repository rather than inferred.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { Prisma, PrismaClient } from "@prisma/client";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { texToHtml } from "../src/components/TeX";
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes("--apply");
+const LINK_LABEL_MAX = 120;
+
+const LIMITS = new Map<string, number>();
+for (const s of [...EDITABLE_FIELDS, ...CURATOR_FIELDS])
+  if (s.maxLength) LIMITS.set(s.key, s.maxLength);
+
+const SLUG =
+  "absence-of-critical-bernoulli-bond-percolation-on-z-d-in-every-dimension-d-2";
+const PIN = "795efb86f191735c5481675763537cfb4ff37e55";
+const BASE = `https://github.com/anthropics/formal-math/blob/${PIN}/percolation`;
+
+const EDITS: Record<string, unknown> = {
+  aiRole:
+    'The repository\'s own provenance section: the Lean sources, "definitions, statements and proofs, together with Challenge.lean, Solution.lean and the metadata", "were written by an AI system (Anthropic\'s Claude models) working autonomously under the direction of Justin Leder; no human wrote or edited the Lean code." Its formalization.yaml records the split: "Discovery, informal proof and Lean formalization were all produced by the AI system operating autonomously. Human role (Justin Leder): problem selection, direction, reading of the statement file and metadata, and responsibility for this submission", the author having "posed the problem, set the acceptance standard (kernel-checked proof with the standard axioms, plus adversarial review of the statements) and directed priorities." The same file states that the only review so far was by AI systems, adversarial reads of the formal statements and of the proof chain against the cited literature, and the README asks readers to satisfy themselves that Challenge.lean states the intended theorem rather than relying on the kernel for that - which is the audit recorded under verification here.',
+
+  ageNote:
+    "The repository discloses about one week of wall time in August 2026, on cloud CPU machines for Lean elaboration plus API inference, with spend not tracked. The problem it closes had been open in dimensions 3 to 10 since Harris settled the planar case in 1960.",
+};
+
+const LINKS = [
+  {
+    label: "summary.pdf: the repository's own guide to the proof",
+    url: `${BASE}/summary.pdf`,
+    kind: "paper",
+  },
+  {
+    label: "formalization.yaml: provenance, cost and disclosed divergences",
+    url: `${BASE}/formalization.yaml`,
+    kind: "other",
+  },
+];
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const cur = await prisma.problem.findUnique({
+    where: { slug: SLUG },
+    select: {
+      id: true,
+      status: true,
+      humanCollaborators: true,
+      aiRole: true,
+      ageNote: true,
+      _count: { select: { links: true } },
+    },
+  });
+  if (!cur) throw new Error(`not found on ${db}: ${SLUG}`);
+  console.log(`status: ${cur.status}`);
+  console.log(
+    `humanCollaborators before: ${JSON.stringify(cur.humanCollaborators)}`,
+  );
+  console.log(`ageNote before           : ${cur.ageNote ?? "(empty)"}`);
+  console.log(`aiRole before            : ${cur.aiRole?.slice(0, 90)}...\n`);
+
+  let bad = 0;
+  for (const [k, v] of Object.entries(EDITS)) {
+    const lim = LIMITS.get(k);
+    if (typeof v === "string" && lim) {
+      const over = v.length > lim;
+      console.log(
+        `  ${k.padEnd(19)}: ${v.length}/${lim}${over ? "  OVER" : ""}`,
+      );
+      if (over) bad++;
+      // aiRole and ageNote both render through <TeX>, so a stray "$" would
+      // either swallow prose or produce a katex-error span.
+      if (v.includes("$")) {
+        const html = texToHtml(v);
+        if (html.includes("katex-error")) {
+          console.log("      katex-error");
+          bad++;
+        }
+      }
+    } else {
+      console.log(`  ${k.padEnd(19)}: ${JSON.stringify(v)}`);
+    }
+  }
+  for (const l of LINKS) {
+    console.log(
+      `  link               : ${l.label.length}/${LINK_LABEL_MAX}  ${l.kind}`,
+    );
+    if (l.label.length > LINK_LABEL_MAX) bad++;
+  }
+  if (bad) throw new Error(`${bad} problem(s) - nothing written`);
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+
+  const n = cur._count.links;
+  await prisma.problem.update({
+    where: { id: cur.id },
+    data: {
+      ...EDITS,
+      links: { create: LINKS.map((l, i) => ({ ...l, position: n + i })) },
+    } as unknown as Prisma.ProblemUpdateInput,
+    select: { id: true },
+  });
+  console.log(
+    "APPLIED. The entry page is cached under problem-<slug> with cacheLife hours, so the public page catches up within an hour or on the next deploy.",
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/fix-percolation-tex-2026-09-08.ts
+++ b/scripts/fix-percolation-tex-2026-09-08.ts
@@ -1,0 +1,124 @@
+// The percolation entry came in with ASCII mathematics - "Z^d", "theta(p)",
+// "d >= 2" - so the entry page showed them literally instead of typeset.
+// This rewrites the fields that are actually TeX-rendered.
+//
+// Which fields may carry TeX, checked in the components rather than assumed:
+//   name, statement, resultNote, verificationNote, aiRole  -> <TeX>, safe.
+//   significanceNote -> <StarNote text={...}> which calls renderBold, NOT
+//     TeX. A "$" here would render as a literal dollar sign, so this field is
+//     left in Unicode.
+//   shortName -> deTeX in cards and meta titles, texToHtml in RelatedEntries,
+//     but printed RAW in FrontierMembership, the frontiers page and stats. It
+//     therefore cannot carry TeX either, and gets Unicode instead.
+//
+// verificationNote is left alone on purpose: its mathematics is Lean source
+// being quoted (SimpleGraph.hasse, Fin d → ℤ, Iff.rfl, propext), and setting
+// code as TeX would be wrong, not prettier.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { PrismaClient } from "@prisma/client";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { texToHtml } from "../src/components/TeX";
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes("--apply");
+
+const LIMITS = new Map<string, number>();
+for (const s of [...EDITABLE_FIELDS, ...CURATOR_FIELDS])
+  if (s.maxLength) LIMITS.set(s.key, s.maxLength);
+
+const SLUG =
+  "absence-of-critical-bernoulli-bond-percolation-on-z-d-in-every-dimension-d-2";
+
+const EDITS: Record<string, string> = {
+  name: "Absence of critical Bernoulli bond percolation on $\\mathbb Z^d$ in every dimension $d \\ge 2$",
+
+  // Unicode, not TeX: this string is printed raw in several places.
+  shortName: "Critical percolation: θ(p_c) = 0",
+
+  statement:
+    "For nearest-neighbour Bernoulli bond percolation on $\\mathbb Z^d$, let $\\theta(p)$ be the probability that the open cluster of the origin is infinite, and let $p_c$ be the critical parameter. Is $\\theta(p_c) = 0$ for every integer $d \\ge 2$?",
+
+  resultNote:
+    "Claims $\\theta(p_c) = 0$ for every $d \\ge 2$, by proving Kozma-Nitzan Conjecture 3 and its reduction to critical percolation. The previously open dimensions $3 \\le d \\le 10$ are included. The formal statement concerns vanishing at $p_c$; continuity of $\\theta$ on the whole interval is a classical consequence rather than the formal target. No claim is intended concerning site percolation or other lattices.",
+};
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const cols = Object.keys(EDITS)
+    .map((c) => `"${c}"`)
+    .join(", ");
+  const [before] = await prisma.$queryRawUnsafe<Record<string, string>[]>(
+    `SELECT ${cols} FROM "Problem" WHERE slug = $1`,
+    SLUG,
+  );
+  if (!before) throw new Error(`not found on ${db}: ${SLUG}`);
+
+  let bad = 0;
+  for (const [k, v] of Object.entries(EDITS)) {
+    const lim = LIMITS.get(k);
+    const over = lim ? v.length > lim : false;
+    console.log(
+      `--- ${k}${lim ? `  ${v.length}/${lim}` : ""}${over ? "  OVER" : ""}`,
+    );
+    console.log(`  before: ${before[k]}`);
+    console.log(`  after : ${v}`);
+    if (over) bad++;
+
+    // Every field that carries TeX must render without a KaTeX error, and the
+    // formulas must actually be recognised as formulas. A silent
+    // katex-error span is how a "$" typo ships.
+    if (v.includes("$")) {
+      const html = texToHtml(v);
+      const spans = html.match(/class="katex"/g)?.length ?? 0;
+      const err = html.includes("katex-error");
+      console.log(`  katex : ${spans} formula(s)${err ? "  ERROR" : ""}`);
+      if (err || spans === 0) bad++;
+    } else if (/\^|_[a-z]|>=|<=/.test(v)) {
+      console.log(
+        "  note  : no TeX here by design (rendered raw or bold-only)",
+      );
+    }
+    console.log();
+  }
+  if (bad) throw new Error(`${bad} problem(s) - nothing written`);
+
+  if (!APPLY) {
+    console.log("DRY RUN - pass --apply to write");
+    return;
+  }
+
+  await prisma.problem.update({
+    where: { slug: SLUG },
+    data: EDITS as never,
+    select: { id: true },
+  });
+  console.log(
+    "APPLIED. Public caches lag until the next deploy; the entry page is right immediately.",
+  );
+}
+
+main().finally(() => prisma.$disconnect());


### PR DESCRIPTION
The percolation submission arrived with ASCII mathematics - `Z^d`, `theta(p)`, `d >= 2` - so the top entry in the catalog was displaying them literally. `name`, `statement` and `resultNote` now carry TeX.

## Which fields may carry TeX

Checked in the components rather than assumed, and the answer is not uniform:

| Field | Renders via | TeX? |
|---|---|---|
| `name`, `statement`, `resultNote`, `verificationNote`, `aiRole` | `<TeX>` | yes |
| `significanceNote` | `<StarNote>` → `renderBold` | **no** |
| `shortName` | `deTeX` in cards, `texToHtml` in RelatedEntries, but **raw** in FrontierMembership / frontiers / stats | **no** |

A `$` in either of the bottom two renders as a literal dollar sign, so `shortName` gets Unicode instead: `θ(p_c) = 0`.

`verificationNote` is left alone deliberately. Its mathematics is quoted Lean source (`SimpleGraph.hasse`, `Fin d → ℤ`, `Iff.rfl`, `propext`), and setting code as TeX would be wrong rather than prettier.

## The dry run actually checks the TeX

Every TeX-bearing field is pushed through `texToHtml` and the run fails on a `katex-error` span, or on a field that produced no formula at all. A stray `$` otherwise ships silently, which is exactly how the kissing-19 entry shipped raw `\(...\)` earlier this month.

Result: name 2 formulas, statement 5, resultNote 5, no errors.

## One thing this exposed, beyond this entry

The line these scripts print - "entry pages are right immediately" - is true only for **new** entries, which have nothing cached. An edit to an already-cached page keeps serving the old render: `getProblemBySlug` sits behind `use cache` with `cacheTag("problems", "problem-<slug>")`, and only a server action calls `revalidateTag`. A script writing straight to the database invalidates nothing.

With `cacheLife("hours")` (`stale 300s, revalidate 3600s, expire 1 day`, read from `config-shared.js` rather than from memory) a direct edit takes up to an hour to appear publicly, or a redeploy to appear now. Worth remembering the next time an edit "doesn't work".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qZdhFeq7ZE7AGQNCF5Mu8

---

## Second commit: quote the repository on the AI role

This began as "credit the directing human" and that turned out to be unnecessary - `humanCollaborators` already read `["Justin Leder"]`, supplied by the submitter. I had inferred it was empty from the inbox script's output, which does not print that column. So what landed is precision of attribution rather than the presence of it.

- **`aiRole`** now quotes `NOTICE`, `README.md` and `formalization.yaml` directly rather than paraphrasing them second-hand through an anonymous submitter: the exact human/AI split, the acceptance standard the author set, and the repository's own statement that the only review so far was by AI systems.
- **`ageNote`** records the disclosed cost: about one week of wall time in August 2026, cloud CPU for elaboration plus API inference, spend not tracked.
- **Two links**: `summary.pdf`, which the README calls "the guide to the proof" while warning the library docstrings "were machine-written as working notes... they are not an exposition", and `formalization.yaml` for provenance and disclosed divergences. Without the first, the entry pointed readers at 97,000 lines of Lean with no route to the human-readable explanation that exists.

Worth recording: the divergences `formalization.yaml` discloses - the `p_c` infimum convention, the Hasse encoding of the lattice, `Sym2` bond configurations - are the same three the review's own statement audit turned up independently. Agreement between a submission's self-disclosure and an independent audit is itself evidence.
