### PR TITLE
Fix scatter label overlap, and add a most-significant-per-month chart

### DIFF
--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -11,6 +11,7 @@ import { MethodGrowthChart } from "@/components/MethodGrowthChart";
 import { Icon, type IconName } from "@/components/Icons";
 import { ModelsChart } from "@/components/ModelsChart";
 import { OpenSourceChart } from "@/components/OpenSourceChart";
+import { PeakChart } from "@/components/PeakChart";
 import { ReferencesChart } from "@/components/ReferencesChart";
 import { SolveRatioChart } from "@/components/SolveRatioChart";
 import { InfoTip } from "@/components/Tooltip";
@@ -202,6 +203,13 @@ export default async function StatsPage() {
             candidate (hollow) and excludes partial/variant/retracted. */}
         <ChartCard id="significance-vs-age" label="significance vs. age">
           <ReferencesChart problems={slim} />
+        </ChartCard>
+        {/* Sits beside the scatter deliberately: both are about weight
+            rather than volume, and this one is the scatter's story rolled
+            forward in time. `slim`, not `resolved`, because a candidate
+            claim under review is still the month's biggest event. */}
+        <ChartCard id="peak-per-month" label="most significant per month">
+          <PeakChart problems={slim} today={today} />
         </ChartCard>
         <ChartCard id="by-vendor" label="solves per vendor">
           <ModelsChart problems={resolved} today={today} />

--- a/src/components/PeakChart.tsx
+++ b/src/components/PeakChart.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { ChartProblem } from "@/lib/problems";
+import { deTeX } from "@/components/TeX";
+import { TimeAxis } from "@/components/TimeControls";
+import {
+  monthlyPeaks,
+  recordMonths,
+  runningPeak,
+  type MonthPeak,
+} from "@/lib/monthly-peak";
+import { labelWidth, placeLabels } from "@/lib/scatter-labels";
+
+// The heaviest problem resolved in each month, from the first solve to today.
+//
+// Every other time chart here counts things, so every other time chart goes up
+// as the catalog grows. This one cannot: a month is worth its best result, so
+// the line only moves when something genuinely bigger lands. It is the one
+// view on the page that shows the ceiling rising rather than the pile
+// deepening.
+//
+// No time-range toggle, unlike its siblings. "From the first entry to today"
+// is the whole point - a windowed version would hide the early flat stretch
+// that gives the recent jumps their meaning.
+
+const VIEW_W = 640;
+const VIEW_H = 360;
+const MARGIN = { top: 30, right: 20, bottom: 40, left: 44 };
+const PLOT_W = VIEW_W - MARGIN.left - MARGIN.right;
+const PLOT_H = VIEW_H - MARGIN.top - MARGIN.bottom;
+
+function niceMax(v: number, step: number) {
+  return Math.max(step, Math.ceil(v / step) * step);
+}
+
+export function PeakChart({
+  problems,
+  today,
+}: {
+  problems: ChartProblem[];
+  today: string;
+}) {
+  const [hover, setHover] = useState<number | null>(null);
+  const router = useRouter();
+
+  const rows: MonthPeak[] = monthlyPeaks(problems, today);
+  if (rows.length === 0) return null;
+
+  const records = recordMonths(rows);
+  const running = runningPeak(rows);
+  const yMax = niceMax(Math.max(10, ...rows.map((r) => r.significance)), 10);
+
+  const months = rows.map((r) => r.month);
+  const x = (i: number) =>
+    MARGIN.left +
+    (rows.length === 1 ? PLOT_W / 2 : (i / (rows.length - 1)) * PLOT_W);
+  const y = (v: number) => MARGIN.top + PLOT_H - (v / yMax) * PLOT_H;
+
+  // Bars thin enough that a long timeline does not turn into a solid block,
+  // and never wider than the gap between months.
+  const barW = Math.max(
+    2,
+    Math.min(14, (PLOT_W / Math.max(1, rows.length)) * 0.6),
+  );
+
+  // Only record-setting months are labelled: on a running-maximum chart every
+  // other month is by definition below a line the reader can already see.
+  // Reuses the scatter's packer, so a run of records in consecutive months
+  // cannot overprint - which is exactly what August and September 2026 are.
+  const placed = placeLabels(
+    rows
+      .map((r, i) => ({ r, i }))
+      .filter(({ r }) => records.has(r.month) && r.top)
+      .reverse()
+      .map(({ r, i }) => ({
+        key: r.month,
+        cx: x(i),
+        cy: y(r.significance),
+        width: labelWidth(deTeX(r.top!.shortName)),
+        anchor:
+          x(i) > VIEW_W - 110
+            ? ("end" as const)
+            : x(i) < MARGIN.left + 110
+              ? ("start" as const)
+              : ("middle" as const),
+      })),
+    {
+      minY: MARGIN.top,
+      maxY: MARGIN.top + PLOT_H,
+      minX: MARGIN.left,
+      maxX: VIEW_W - MARGIN.right,
+    },
+  );
+
+  const ticks: number[] = [];
+  for (let v = 0; v <= yMax; v += yMax / 3) ticks.push(Math.round(v));
+
+  const active = hover !== null ? rows[hover] : null;
+  // The record line as a step: it holds its level through empty months rather
+  // than sloping between results, because nothing happened in between.
+  const stepPath = running
+    .map((v, i) => {
+      const px = x(i);
+      const py = y(v);
+      return i === 0
+        ? `M ${px} ${py}`
+        : `L ${px} ${y(running[i - 1])} L ${px} ${py}`;
+    })
+    .join(" ");
+
+  return (
+    <div>
+      <h2 className="font-serif text-lg text-[var(--ink)]">
+        Most significant result per month
+      </h2>
+      <p className="mt-1 text-xs text-[var(--ink-muted)]">
+        The heaviest problem resolved in each month since the record begins.
+        Unlike the other charts here this one does not rise with volume: it
+        moves only when something bigger lands. The line is the running best.
+      </p>
+
+      <svg
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        className="mt-3 w-full overflow-visible"
+        role="img"
+        aria-label="Bar chart of the highest significance resolved in each month, with a running-best line that steps up when a new record lands."
+      >
+        {ticks.map((t) => (
+          <g key={t}>
+            <line
+              x1={MARGIN.left}
+              x2={VIEW_W - MARGIN.right}
+              y1={y(t)}
+              y2={y(t)}
+              stroke="var(--rule)"
+              strokeWidth={1}
+            />
+            <text
+              x={MARGIN.left - 8}
+              y={y(t) + 4}
+              textAnchor="end"
+              style={{ fontSize: 11, fill: "var(--ink-muted)" }}
+            >
+              {t}
+            </text>
+          </g>
+        ))}
+
+        {/* 18px below the baseline, the same offset every sibling chart uses.
+            Passing the baseline itself drew the month labels through the
+            bottoms of the bars. */}
+        <TimeAxis
+          range={months}
+          gran="month"
+          x={x}
+          y={VIEW_H - MARGIN.bottom + 18}
+        />
+
+        {/* The running best, drawn under the bars so a record month's bar
+            sits on top of the step it created. */}
+        <path
+          d={stepPath}
+          fill="none"
+          stroke="var(--accent-orange)"
+          strokeWidth={1.5}
+          strokeOpacity={0.65}
+        />
+
+        {rows.map((r, i) => {
+          if (!r.top) return null;
+          const isRecord = records.has(r.month);
+          const h = MARGIN.top + PLOT_H - y(r.significance);
+          return (
+            <rect
+              key={r.month}
+              x={x(i) - barW / 2}
+              y={y(r.significance)}
+              width={barW}
+              height={Math.max(1, h)}
+              rx={1}
+              fill="var(--accent-blue)"
+              fillOpacity={hover === i ? 1 : isRecord ? 0.95 : 0.5}
+            />
+          );
+        })}
+
+        {/* Hit strips: one per month, full height, so hovering anywhere in a
+            column works rather than only on a two-pixel bar. */}
+        {rows.map((r, i) => (
+          <rect
+            key={`hit-${r.month}`}
+            x={x(i) - PLOT_W / Math.max(1, rows.length) / 2}
+            y={MARGIN.top}
+            width={Math.max(4, PLOT_W / Math.max(1, rows.length))}
+            height={PLOT_H}
+            fill="transparent"
+            style={{ cursor: r.top ? "pointer" : "default" }}
+            onMouseEnter={() => setHover(i)}
+            onMouseLeave={() => setHover(null)}
+            onClick={() => r.top && router.push(`/problem/${r.top.slug}`)}
+          />
+        ))}
+
+        {rows.map((r, i) => {
+          const label = placed.get(r.month);
+          if (!label || !r.top) return null;
+          return (
+            <text
+              key={`lab-${r.month}`}
+              x={label.x}
+              y={label.y}
+              textAnchor={label.anchor}
+              style={{ fontSize: 11, fill: "var(--ink)" }}
+            >
+              {deTeX(r.top.shortName)}
+            </text>
+          );
+        })}
+      </svg>
+
+      <p className="mt-2 min-h-[2.5rem] text-xs text-[var(--ink-secondary)]">
+        {active?.top ? (
+          <>
+            <span className="text-[var(--ink)]">
+              {deTeX(active.top.shortName)}
+            </span>{" "}
+            &middot; {active.significance}/100 &middot; {active.month}
+          </>
+        ) : (
+          <>
+            {records.size} months set a new record. Hover a month for its
+            result, click to open it.
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/src/components/ReferencesChart.tsx
+++ b/src/components/ReferencesChart.tsx
@@ -6,6 +6,7 @@ import { ageAtSolve, type ChartProblem } from "@/lib/problems";
 import { useChartSettings } from "@/lib/chart-settings";
 import { TierToggle } from "@/components/TimeControls";
 import { TeX, deTeX } from "@/components/TeX";
+import { labelWidth, placeLabels } from "@/lib/scatter-labels";
 
 // This chart plots SIGNIFICANCE (the AI-estimated problem weight) against how
 // long the problem stood open. The dense band at 10 is the point: almost every
@@ -39,6 +40,16 @@ const MARGIN = { top: 34, right: 24, bottom: 44, left: 56 };
 const PLOT_W = VIEW_W - MARGIN.left - MARGIN.right;
 const PLOT_H = VIEW_H - MARGIN.top - MARGIN.bottom;
 
+/// Labels near either edge anchor inward so they stay inside the viewBox -
+/// the svg has overflow visible, and a centred label on an edge point would
+/// poke out of the card (and on phones, widen the page). Shared with the
+/// label packer, which has to measure the box the renderer actually draws.
+function labelAnchorAt(cx: number): "start" | "middle" | "end" {
+  if (cx > VIEW_W - 100) return "end";
+  if (cx < MARGIN.left + 100) return "start";
+  return "middle";
+}
+
 function niceMax(value: number, step: number) {
   return Math.max(step, Math.ceil(value / step) * step);
 }
@@ -55,7 +66,12 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
   // Legend chips toggle point groups (proved / disproved / under review),
   // persisted across reloads. Axes stay fixed so toggling declutters without
   // reflowing the plot.
-  const { tier, setTier, hidden, toggleSeries: toggleGroup } = useChartSettings("scatter");
+  const {
+    tier,
+    setTier,
+    hidden,
+    toggleSeries: toggleGroup,
+  } = useChartSettings("scatter");
 
   // Resolved entries plot as filled dots; CANDIDATE entries (a full solution
   // claimed and vetted, community review pending) plot as hollow rings so a
@@ -73,8 +89,12 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
   const plottable = enriched.filter(
     (
       d,
-    ): d is { problem: ChartProblem; age: number; significance: number; claimed: boolean } =>
-      d.age !== null && d.significance !== null,
+    ): d is {
+      problem: ChartProblem;
+      age: number;
+      significance: number;
+      claimed: boolean;
+    } => d.age !== null && d.significance !== null,
   );
   const pending = enriched.length - plottable.length;
   // Dropped before `enriched` even exists: partials and variants improve a
@@ -86,7 +106,10 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
 
   const xMax = niceMax(Math.max(1, ...plottable.map((d) => d.age)), 20);
   const yStep = 10;
-  const yMax = niceMax(Math.max(1, ...plottable.map((d) => d.significance)), yStep);
+  const yMax = niceMax(
+    Math.max(1, ...plottable.map((d) => d.significance)),
+    yStep,
+  );
 
   const xTicks = ticks(xMax, 20);
   const yTicks = ticks(yMax, yStep);
@@ -95,9 +118,9 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
   const y = (sig: number) => MARGIN.top + PLOT_H - (sig / yMax) * PLOT_H;
 
   // Legend reflects only series actually drawn as points.
-  const seriesPresent = Array.from(new Set(plottable.map((d) => d.problem.solveType))).filter(
-    (t) => t in SOLVE_TYPE_COLOR,
-  );
+  const seriesPresent = Array.from(
+    new Set(plottable.map((d) => d.problem.solveType)),
+  ).filter((t) => t in SOLVE_TYPE_COLOR);
 
   // The tier filter hides POINTS but never touches the axes above, which are
   // still scaled from the full plottable set. Deliberate, and the same reason
@@ -115,37 +138,42 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
   // Draw the dense low band first so the labeled strikes sit on top of it.
   const drawOrder = [...shown].sort((a, b) => a.significance - b.significance);
 
-  // Label de-collision: several labeled points share a score band (four sit
-  // at 35), so neighbouring labels would overprint. Greedy level stacking:
-  // walk labeled points left to right and lift a label one 14px row for each
-  // already-placed label it would collide with (close in x AND in y).
-  const labelYBySlug = new Map<string, number>();
-  {
-    const placed: { cx: number; w: number; labelY: number }[] = [];
-    const labeled = plottable
+  // Label de-collision. See src/lib/scatter-labels.ts for the packing and why
+  // it drops rather than overprints. Three things matter at this call site:
+  //
+  // Placement runs over `shown`, not `plottable`, so the legend and tier
+  // filters actually declutter the plot. Laying out hidden points reserved
+  // space nothing occupied and pushed visible labels off their own dots.
+  //
+  // Order is by significance, highest first, so when the crowded middle band
+  // runs out of room the name that survives is the one a reader came for.
+  //
+  // The anchor has to match what the renderer draws below, or the collision
+  // test measures a box the label does not occupy.
+  const labelYBySlug = placeLabels(
+    shown
       .filter((d) => d.significance >= LABEL_THRESHOLD)
-      .sort((a, b) => x(a.age) - x(b.age));
-    for (const d of labeled) {
-      const cx = x(d.age);
-      // Estimated rendered width at fontSize 14 - the collision test must use
-      // the actual text lengths, or long neighbours still overprint. Measured
-      // on the deTeX'd form, which is what the label actually draws: a
-      // math-bearing short name is shorter rendered than its $...$ source.
-      const w = deTeX(d.problem.shortName).length * 6.4 + 8;
-      let labelY = y(d.significance) - 12;
-      // Lift one line at a time until no placed label overlaps horizontally
-      // at this height.
-      for (let guard = 0; guard < 6; guard++) {
-        const hit = placed.some(
-          (p) => Math.abs(p.cx - cx) < (p.w + w) / 2 && Math.abs(p.labelY - labelY) < 13,
-        );
-        if (!hit) break;
-        labelY -= 13;
-      }
-      placed.push({ cx, w, labelY });
-      labelYBySlug.set(d.problem.slug, labelY);
-    }
-  }
+      .sort((a, b) => b.significance - a.significance)
+      .map((d) => {
+        const cx = x(d.age);
+        return {
+          key: d.problem.slug,
+          cx,
+          cy: y(d.significance),
+          width: labelWidth(deTeX(d.problem.shortName)),
+          anchor: labelAnchorAt(cx),
+        };
+      }),
+    {
+      minY: MARGIN.top,
+      maxY: MARGIN.top + PLOT_H,
+      minX: MARGIN.left,
+      maxX: VIEW_W - MARGIN.right,
+      // Every drawn dot is an obstacle. Clearing only other labels left text
+      // written straight through the scatter.
+      points: shown.map((d) => ({ x: x(d.age), y: y(d.significance) })),
+    },
+  );
 
   return (
     <div>
@@ -199,11 +227,14 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
 
       <p className="mt-1 text-xs text-[var(--ink-muted)]">
         AI-estimated problem weight before the solve, 0-100 (Riemann = 100).
-        Hollow points are claimed solutions still under review. Click a point
-        to open it.
+        Hollow points are claimed solutions still under review. Click a point to
+        open it.
       </p>
 
-      <div className="relative mt-3" style={{ aspectRatio: `${VIEW_W} / ${VIEW_H}` }}>
+      <div
+        className="relative mt-3"
+        style={{ aspectRatio: `${VIEW_W} / ${VIEW_H}` }}
+      >
         <svg
           viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
           className="h-full w-full overflow-visible"
@@ -249,7 +280,11 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
               y={VIEW_H - MARGIN.bottom + 20}
               textAnchor="middle"
               className="font-mono"
-              style={{ fontSize: 12, fill: "var(--ink-muted)", fontVariantNumeric: "tabular-nums" }}
+              style={{
+                fontSize: 12,
+                fill: "var(--ink-muted)",
+                fontVariantNumeric: "tabular-nums",
+              }}
             >
               {t}
             </text>
@@ -272,7 +307,11 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
               dominantBaseline="middle"
               textAnchor="end"
               className="font-mono"
-              style={{ fontSize: 12, fill: "var(--ink-muted)", fontVariantNumeric: "tabular-nums" }}
+              style={{
+                fontSize: 12,
+                fill: "var(--ink-muted)",
+                fontVariantNumeric: "tabular-nums",
+              }}
             >
               {t}
             </text>
@@ -298,8 +337,11 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
             // viewBox - the svg has overflow visible, and a centred label on
             // an edge point would poke out of the card (and on phones, widen
             // the page).
-            const labelAnchor =
-              cx > VIEW_W - 100 ? "end" : cx < MARGIN.left + 100 ? "start" : "middle";
+            // Undefined when the packer found no clear slot: the label is
+            // dropped, not stacked on top of a neighbour. When it is defined
+            // it carries its own x and anchor, because a label may be placed
+            // beside its dot rather than over it.
+            const label = labelYBySlug.get(problem.slug);
             return (
               <g
                 key={problem.slug}
@@ -312,7 +354,8 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
                 onBlur={() => setActiveSlug(null)}
                 onClick={() => router.push(`/problem/${problem.slug}`)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") router.push(`/problem/${problem.slug}`);
+                  if (e.key === "Enter")
+                    router.push(`/problem/${problem.slug}`);
                 }}
                 style={{ cursor: "pointer", outline: "none" }}
               >
@@ -339,11 +382,11 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
                     strokeWidth={isOutlier ? 2 : 1}
                   />
                 )}
-                {isOutlier && (
+                {isOutlier && label && (
                   <text
-                    x={cx}
-                    y={labelYBySlug.get(problem.slug) ?? cy - 12}
-                    textAnchor={labelAnchor}
+                    x={label.x}
+                    y={label.y}
+                    textAnchor={label.anchor}
                     // No halo. It used to paint a 3.5px paper-coloured stroke
                     // behind the glyphs so labels stayed legible over
                     // gridlines, which worked until Chrome's auto-dark got
@@ -375,9 +418,13 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
               transform: "translate(-50%, calc(-100% - 16px))",
             }}
           >
-            <p className="font-serif text-sm text-[var(--ink)]"><TeX>{active.problem.name}</TeX></p>
+            <p className="font-serif text-sm text-[var(--ink)]">
+              <TeX>{active.problem.name}</TeX>
+            </p>
             <p className="mt-1 text-[var(--ink-secondary)]">
-              {active.problem.field ?? SOLVE_TYPE_LABEL[active.problem.solveType] ?? active.problem.solveType}
+              {active.problem.field ??
+                SOLVE_TYPE_LABEL[active.problem.solveType] ??
+                active.problem.solveType}
             </p>
             <dl className="mt-2 grid grid-cols-2 gap-x-2 gap-y-1 font-mono text-[var(--ink-secondary)]">
               <dt className="text-[var(--ink-muted)]">Age</dt>

--- a/src/lib/monthly-peak.test.ts
+++ b/src/lib/monthly-peak.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  eligible,
+  monthlyPeaks,
+  recordMonths,
+  runningPeak,
+} from "@/lib/monthly-peak";
+import type { ChartProblem } from "@/lib/problems";
+
+const p = (
+  slug: string,
+  solveDate: string,
+  significance: number | null,
+  extra: Partial<ChartProblem> = {},
+): ChartProblem =>
+  ({
+    slug,
+    name: slug,
+    shortName: slug,
+    problemNumber: null,
+    field: "",
+    fieldGroup: "Analysis",
+    solveDate,
+    solveType: "proved",
+    resolution: "resolved",
+    resolutionMethod: "argument",
+    aiContribution: "ai-discovered",
+    model: "",
+    modelMaker: "",
+    verification: "unreviewed",
+    yearPosed: 2000,
+    significance,
+    ...extra,
+  }) as ChartProblem;
+
+describe("eligible", () => {
+  it("takes resolved and candidate entries", () => {
+    expect(eligible(p("a", "2026-01-05", 10))).toBe(true);
+    expect(
+      eligible(p("b", "2026-01-05", 10, { resolution: "candidate" })),
+    ).toBe(true);
+  });
+
+  it("rejects partials and variants, which have no moment of resolution", () => {
+    expect(eligible(p("c", "2026-01-05", 10, { resolution: "partial" }))).toBe(
+      false,
+    );
+    expect(eligible(p("d", "2026-01-05", 10, { resolution: "variant" }))).toBe(
+      false,
+    );
+  });
+
+  it("rejects an entry with no score or no date", () => {
+    expect(eligible(p("e", "2026-01-05", null))).toBe(false);
+    expect(eligible(p("f", "", 10))).toBe(false);
+  });
+});
+
+describe("monthlyPeaks", () => {
+  it("keeps the heaviest entry of each month", () => {
+    const rows = monthlyPeaks(
+      [
+        p("small", "2026-01-04", 10),
+        p("big", "2026-01-20", 70),
+        p("mid", "2026-01-28", 40),
+      ],
+      "2026-01-31",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].top?.slug).toBe("big");
+    expect(rows[0].significance).toBe(70);
+  });
+
+  it("keeps empty months as gaps so the axis stays a timeline", () => {
+    const rows = monthlyPeaks(
+      [p("a", "2026-01-10", 20), p("b", "2026-04-10", 30)],
+      "2026-04-30",
+    );
+    expect(rows.map((r) => r.month)).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2026-04",
+    ]);
+    expect(rows[1].top).toBeNull();
+    expect(rows[1].significance).toBe(0);
+  });
+
+  it("runs to today, not to the last solve", () => {
+    // A quiet stretch is information. Ending the axis at the last result
+    // would imply the record ended with it.
+    const rows = monthlyPeaks([p("a", "2026-01-10", 20)], "2026-05-15");
+    expect(rows[rows.length - 1].month).toBe("2026-05");
+    expect(rows[rows.length - 1].top).toBeNull();
+  });
+
+  it("breaks ties towards the earlier solve", () => {
+    const rows = monthlyPeaks(
+      [p("later", "2026-02-20", 50), p("earlier", "2026-02-03", 50)],
+      "2026-02-28",
+    );
+    expect(rows[0].top?.slug).toBe("earlier");
+  });
+
+  it("returns nothing when no entry qualifies", () => {
+    expect(monthlyPeaks([p("a", "2026-01-01", null)], "2026-02-01")).toEqual(
+      [],
+    );
+  });
+
+  it("survives a solve dated after today", () => {
+    // Clock skew or a mis-keyed date should not collapse the range.
+    const rows = monthlyPeaks([p("a", "2027-01-10", 20)], "2026-05-15");
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0].top?.slug).toBe("a");
+  });
+});
+
+describe("runningPeak", () => {
+  it("never falls", () => {
+    const rows = monthlyPeaks(
+      [
+        p("a", "2026-01-10", 30),
+        p("b", "2026-02-10", 10),
+        p("c", "2026-03-10", 55),
+      ],
+      "2026-03-31",
+    );
+    expect(runningPeak(rows)).toEqual([30, 30, 55]);
+  });
+
+  it("holds its level across empty months", () => {
+    const rows = monthlyPeaks(
+      [p("a", "2026-01-10", 30), p("b", "2026-03-10", 20)],
+      "2026-03-31",
+    );
+    expect(runningPeak(rows)).toEqual([30, 30, 30]);
+  });
+});
+
+describe("recordMonths", () => {
+  it("marks only the months that set a new high", () => {
+    const rows = monthlyPeaks(
+      [
+        p("a", "2026-01-10", 30),
+        p("b", "2026-02-10", 20),
+        p("c", "2026-03-10", 55),
+        p("d", "2026-04-10", 55),
+      ],
+      "2026-04-30",
+    );
+    expect([...recordMonths(rows)].sort()).toEqual(["2026-01", "2026-03"]);
+  });
+
+  it("does not mark an empty month", () => {
+    const rows = monthlyPeaks(
+      [p("a", "2026-01-10", 30), p("b", "2026-03-10", 40)],
+      "2026-03-31",
+    );
+    expect(recordMonths(rows).has("2026-02")).toBe(false);
+  });
+});

--- a/src/lib/monthly-peak.ts
+++ b/src/lib/monthly-peak.ts
@@ -1,0 +1,109 @@
+// "Most significant per month": for every month from the first solve to
+// today, the single heaviest problem resolved in it.
+//
+// The other time charts on /stats count things - entries per week, cumulative
+// totals, share by area - and all of them go up simply because the catalog
+// grows. This one cannot: a month's value is the weight of its best result,
+// so it only rises when something genuinely bigger lands. That makes it the
+// one chart on the page that shows a ceiling moving rather than a pile
+// getting taller, which is the actual claim the site exists to document.
+//
+// Months with nothing in them are kept as gaps rather than dropped, so the
+// x axis stays a real timeline: the run of empty months early on is part of
+// the story, not noise to be compressed away.
+
+import { bucketKey, bucketRange } from "@/lib/time-buckets";
+import type { ChartProblem } from "@/lib/problems";
+
+export interface MonthPeak {
+  /// "YYYY-MM".
+  month: string;
+  /// The heaviest entry resolved this month, or null if the month is empty.
+  top: ChartProblem | null;
+  /// Its significance, or 0 for an empty month.
+  significance: number;
+}
+
+/// Entries that can appear on this chart at all: a resolution that means the
+/// problem is actually settled, a solve date to place it, and a score to
+/// plot. Partials and variants are excluded for the same reason they are
+/// excluded from the age scatter - a bound improvement has no single moment
+/// of resolution - and candidates are kept because a claimed solution under
+/// review is still the biggest thing that happened that month.
+export function eligible(p: ChartProblem): boolean {
+  return (
+    (p.resolution === "resolved" || p.resolution === "candidate") &&
+    typeof p.solveDate === "string" &&
+    p.solveDate.length >= 7 &&
+    typeof p.significance === "number"
+  );
+}
+
+/**
+ * Bucket problems by solve month and keep the heaviest of each.
+ *
+ * `today` bounds the right edge so the axis ends at the present rather than
+ * at the last solve, which matters when nothing has landed for a few weeks:
+ * a chart that stops at the last result implies the record stopped too.
+ */
+export function monthlyPeaks(
+  problems: ChartProblem[],
+  today: string,
+): MonthPeak[] {
+  const usable = problems.filter(eligible);
+  if (usable.length === 0) return [];
+
+  const best = new Map<string, ChartProblem>();
+  for (const p of usable) {
+    const key = bucketKey(p.solveDate as string, "month");
+    const prev = best.get(key);
+    // Ties break towards the earlier solve date, so the month credits
+    // whichever result got there first.
+    if (
+      !prev ||
+      (p.significance as number) > (prev.significance as number) ||
+      ((p.significance as number) === (prev.significance as number) &&
+        (p.solveDate as string) < (prev.solveDate as string))
+    ) {
+      best.set(key, p);
+    }
+  }
+
+  const first = [...best.keys()].sort()[0];
+  const last = bucketKey(today, "month");
+  // A solve dated in the future would otherwise produce an empty range.
+  const end = last >= first ? last : [...best.keys()].sort().slice(-1)[0];
+
+  return bucketRange(first, end, "month").map((month) => {
+    const top = best.get(month) ?? null;
+    return {
+      month,
+      top,
+      significance: top ? (top.significance as number) : 0,
+    };
+  });
+}
+
+/// The running maximum, so the chart can draw the record line: the highest
+/// significance seen up to and including each month. Never falls.
+export function runningPeak(rows: MonthPeak[]): number[] {
+  let best = 0;
+  return rows.map((r) => {
+    best = Math.max(best, r.significance);
+    return best;
+  });
+}
+
+/// Months whose peak set a new all-time high. These are the only months worth
+/// labelling: everything else is noise against the record line.
+export function recordMonths(rows: MonthPeak[]): Set<string> {
+  const out = new Set<string>();
+  let best = 0;
+  for (const r of rows) {
+    if (r.top && r.significance > best) {
+      best = r.significance;
+      out.add(r.month);
+    }
+  }
+  return out;
+}

--- a/src/lib/scatter-labels.test.ts
+++ b/src/lib/scatter-labels.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import {
+  extent,
+  labelWidth,
+  placeLabels,
+  type LabelInput,
+  type Placement,
+} from "@/lib/scatter-labels";
+
+const BOUNDS = { minY: 34, maxY: 316, minX: 56, maxX: 616 };
+
+const at = (key: string, cx: number, cy: number, width = 60): LabelInput => ({
+  key,
+  cx,
+  cy,
+  width,
+  anchor: "middle",
+});
+
+/// Do two placed labels overlap? The property every test below really cares
+/// about, expressed once.
+function overlaps(a: LabelInput, ap: Placement, b: LabelInput, bp: Placement) {
+  const [a0, a1] = extent(ap.x, a.width, ap.anchor);
+  const [b0, b1] = extent(bp.x, b.width, bp.anchor);
+  return Math.abs(ap.y - bp.y) < 13 && a0 < b1 && a1 > b0;
+}
+
+describe("placeLabels", () => {
+  it("places an isolated label just above its point", () => {
+    const out = placeLabels([at("a", 200, 200)], BOUNDS);
+    expect(out.get("a")?.y).toBe(188);
+  });
+
+  it("lifts the second of two colliding labels instead of overprinting", () => {
+    const a = at("a", 200, 200);
+    const b = at("b", 210, 200);
+    const out = placeLabels([a, b], BOUNDS);
+    expect(out.size).toBe(2);
+    expect(overlaps(a, out.get("a")!, b, out.get("b")!)).toBe(false);
+  });
+
+  it("leaves labels alone when they are far apart horizontally", () => {
+    const out = placeLabels([at("a", 100, 200), at("b", 400, 200)], BOUNDS);
+    expect(out.get("a")?.y).toBe(188);
+    expect(out.get("b")?.y).toBe(188);
+  });
+
+  it("DROPS a label rather than overprint when the ladder is exhausted", () => {
+    // Twenty labels stacked on one point cannot all fit. The old stacker gave
+    // up after six lifts and drew them anyway; this is the regression that
+    // produced the unreadable pile at the top of the chart.
+    const many = Array.from({ length: 20 }, (_, i) => at(`n${i}`, 200, 200));
+    const out = placeLabels(many, BOUNDS);
+    expect(out.size).toBeLessThan(20);
+    expect(out.size).toBeGreaterThan(0);
+    // Whatever survived must be mutually clear.
+    const kept = many.filter((m) => out.has(m.key));
+    for (let i = 0; i < kept.length; i++)
+      for (let j = i + 1; j < kept.length; j++)
+        expect(
+          overlaps(
+            kept[i],
+            out.get(kept[i].key)!,
+            kept[j],
+            out.get(kept[j].key)!,
+          ),
+        ).toBe(false);
+  });
+
+  it("never places a label above the top margin", () => {
+    // A point at the very top of the plot has almost no headroom, so most of
+    // the ladder is out of bounds; anything placed must still be inside.
+    const many = Array.from({ length: 8 }, (_, i) => at(`n${i}`, 200, 40));
+    const out = placeLabels(many, BOUNDS);
+    for (const p of out.values())
+      expect(p.y).toBeGreaterThanOrEqual(BOUNDS.minY);
+  });
+
+  it("never places a label below the baseline", () => {
+    const many = Array.from({ length: 8 }, (_, i) => at(`n${i}`, 200, 310));
+    const out = placeLabels(many, BOUNDS);
+    for (const p of out.values()) expect(p.y).toBeLessThanOrEqual(BOUNDS.maxY);
+  });
+
+  it("falls below the point when there is no room above", () => {
+    // Pinned at the ceiling: the only free slots are the downward rungs.
+    const out = placeLabels([at("a", 200, 36)], BOUNDS);
+    expect(out.get("a")?.y).toBeGreaterThan(36);
+  });
+
+  it("packs in the caller's order, so earlier items win the slot", () => {
+    const first = at("first", 200, 200);
+    const second = at("second", 205, 200);
+    const out = placeLabels([first, second], BOUNDS);
+    // The first keeps the slot nearest its point.
+    expect(out.get("first")?.y).toBe(188);
+    expect(out.get("second")?.y).not.toBe(188);
+  });
+
+  it("avoids writing a label through a plotted point", () => {
+    // A dot sitting exactly where the first rung would put the text. The
+    // first version of this fix cleared label-vs-label but happily punched
+    // points through the middle of words.
+    const a = at("a", 200, 200);
+    const out = placeLabels([a], { ...BOUNDS, points: [{ x: 200, y: 188 }] });
+    expect(out.get("a")?.y).not.toBe(188);
+  });
+
+  it("does not treat a label's own point as an obstacle", () => {
+    const a = at("a", 200, 200);
+    const out = placeLabels([a], { ...BOUNDS, points: [{ x: 200, y: 200 }] });
+    expect(out.get("a")?.y).toBe(188);
+  });
+
+  it("ignores points far from the label box", () => {
+    const a = at("a", 200, 200);
+    const out = placeLabels([a], { ...BOUNDS, points: [{ x: 400, y: 188 }] });
+    expect(out.get("a")?.y).toBe(188);
+  });
+
+  it("respects the anchor when testing overlap", () => {
+    // Two points 40 apart with 60-wide labels: centred they overlap, but
+    // anchored away from each other they do not, and both should sit on the
+    // first rung. Testing edge labels as if centred is what let them collide.
+    const a: LabelInput = {
+      key: "a",
+      cx: 200,
+      cy: 200,
+      width: 60,
+      anchor: "end",
+    };
+    const b: LabelInput = {
+      key: "b",
+      cx: 240,
+      cy: 200,
+      width: 60,
+      anchor: "start",
+    };
+    const out = placeLabels([a, b], BOUNDS);
+    expect(out.get("a")?.y).toBe(188);
+    expect(out.get("b")?.y).toBe(188);
+  });
+
+  it("keeps every label inside the horizontal bounds", () => {
+    // A wide label on a point near the right edge must not run off the plot,
+    // whatever slot it lands in.
+    const wide: LabelInput = {
+      key: "w",
+      cx: 600,
+      cy: 200,
+      width: 140,
+      anchor: "end",
+    };
+    const out = placeLabels([wide], BOUNDS);
+    const p = out.get("w");
+    if (p) {
+      const [x0, x1] = extent(p.x, wide.width, p.anchor);
+      expect(x0).toBeGreaterThanOrEqual(BOUNDS.minX);
+      expect(x1).toBeLessThanOrEqual(BOUNDS.maxX);
+    }
+  });
+
+  it("puts a label beside its point when the space above is taken", () => {
+    // The crowded band runs diagonally, so points there stack vertically and
+    // the free space is sideways. Blocking every vertical slot with dots
+    // should push the label to a side slot rather than drop it.
+    const a = at("a", 300, 200, 50);
+    const blockers = [-12, -25, 18, -38, 31, -51].map((dy) => ({
+      x: 300,
+      y: 200 + dy,
+    }));
+    const out = placeLabels([a], { ...BOUNDS, points: blockers });
+    const p = out.get("a");
+    expect(p).toBeDefined();
+    expect(p!.anchor).not.toBe("middle");
+    expect(p!.x).not.toBe(300);
+  });
+
+  it("recovers labels that a vertical-only ladder would have dropped", () => {
+    // Five points stacked in a column, the shape the diagonal band makes.
+    // With only up/down slots most of these collide and get dropped; with
+    // side slots they fan out. This is the whole reason side slots exist.
+    const column = [0, 1, 2, 3, 4].map((i) =>
+      at(`c${i}`, 300, 150 + i * 14, 70),
+    );
+    const out = placeLabels(column, {
+      ...BOUNDS,
+      points: column.map((c) => ({ x: c.cx, y: c.cy })),
+    });
+    expect(out.size).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("labelWidth", () => {
+  it("grows with the text", () => {
+    expect(labelWidth("Köthe Conjecture")).toBeGreaterThan(labelWidth("KLS"));
+  });
+
+  it("is generous rather than tight", () => {
+    // 16 characters at 12px should not be estimated under ~100px; an
+    // under-estimate is what lets neighbours touch.
+    expect(labelWidth("Köthe Conjecture")).toBeGreaterThan(100);
+  });
+});
+
+describe("extent", () => {
+  it("centres a middle-anchored label on its point", () => {
+    expect(extent(100, 40, "middle")).toEqual([80, 120]);
+  });
+
+  it("puts a start-anchored label entirely to the right", () => {
+    expect(extent(100, 40, "start")).toEqual([100, 140]);
+  });
+
+  it("puts an end-anchored label entirely to the left", () => {
+    expect(extent(100, 40, "end")).toEqual([60, 100]);
+  });
+});

--- a/src/lib/scatter-labels.ts
+++ b/src/lib/scatter-labels.ts
@@ -1,0 +1,163 @@
+// Label placement for the significance scatter on /stats.
+//
+// The chart labels every point above a significance threshold. As the catalog
+// filled up, the labelled band stopped being "a few outliers in the sparse
+// corner" and became roughly two dozen names inside one crowded rectangle,
+// and the old greedy stacker printed them on top of each other: it lifted a
+// label by one row per collision but gave up after six lifts and drew the
+// label anyway, so the densest region - exactly the region that needed help -
+// got the worst pile.
+//
+// Three rules replace that:
+//
+//   - Search a ladder of candidate slots: above the point, below it, and
+//     BESIDE it. Sideways matters more than it sounds. The crowded band runs
+//     diagonally, so points there are stacked vertically at similar x, and
+//     the free space is to their left and right rather than overhead.
+//   - Treat the plotted dots as obstacles too, not just other labels. Text
+//     written through the scatter is as unreadable as text written through
+//     text.
+//   - If nothing is free, DROP the label rather than overprint. A dropped
+//     label costs one name; an overprinted one costs every name under it,
+//     and the points stay hover- and click-discoverable either way.
+//
+// Kept out of the component and free of React so the packing can be tested
+// directly, which is the only way to know a change here helps rather than
+// rearranges the mess.
+
+export type LabelAnchor = "start" | "middle" | "end";
+
+export interface LabelInput {
+  key: string;
+  /// Point centre, in viewBox units.
+  cx: number;
+  cy: number;
+  /// Estimated rendered text width.
+  width: number;
+  /// Anchor to use for the slots directly above and below the point. Edge
+  /// points anchor inward so the text stays inside the viewBox.
+  anchor: LabelAnchor;
+}
+
+export interface Placement {
+  x: number;
+  y: number;
+  anchor: LabelAnchor;
+}
+
+export interface PlaceOptions {
+  /// Labels may not climb above this line, nor fall below maxY.
+  minY: number;
+  maxY: number;
+  /// Nor extend outside these, which are the plot's horizontal bounds.
+  minX: number;
+  maxX: number;
+  /// Row height, and the vertical clearance two labels need.
+  rowH?: number;
+  /// Every plotted dot, as an obstacle.
+  points?: { x: number; y: number }[];
+  /// Dot radius to keep clear of.
+  pointR?: number;
+}
+
+/// Candidate slots, in preference order, as offsets from the point. `side`
+/// overrides the label's own anchor: a label placed to the right of its dot
+/// must anchor at its left edge whatever the point's position implies.
+///
+/// Above first, because a label reads as belonging to the dot beneath it.
+/// Then beside, then below, then further out.
+const LADDER: { dx: number; dy: number; side?: LabelAnchor }[] = [
+  { dx: 0, dy: -12 },
+  { dx: 8, dy: 4, side: "start" },
+  { dx: -8, dy: 4, side: "end" },
+  { dx: 0, dy: -25 },
+  { dx: 0, dy: 18 },
+  { dx: 8, dy: -8, side: "start" },
+  { dx: -8, dy: -8, side: "end" },
+  { dx: 0, dy: -38 },
+  { dx: 0, dy: 31 },
+  { dx: 8, dy: 16, side: "start" },
+  { dx: -8, dy: 16, side: "end" },
+  { dx: 0, dy: -51 },
+];
+
+/// Horizontal extent of a label drawn at `x` with the given anchor. The
+/// collision test has to agree with what the renderer actually draws: an
+/// edge-anchored label occupies one side of its point, not both, and testing
+/// it as centred was letting edge labels overlap their neighbours.
+export function extent(
+  x: number,
+  width: number,
+  anchor: LabelAnchor,
+): [number, number] {
+  if (anchor === "start") return [x, x + width];
+  if (anchor === "end") return [x - width, x];
+  return [x - width / 2, x + width / 2];
+}
+
+/**
+ * Choose a position for each label, or leave it out when there is no room.
+ *
+ * Points are packed in the caller's order, so pass them most-important first:
+ * whoever comes first gets the slot, and the ones dropped are the ones the
+ * caller cared least about.
+ */
+export function placeLabels(
+  items: LabelInput[],
+  {
+    minY,
+    maxY,
+    minX,
+    maxX,
+    rowH = 13,
+    points = [],
+    pointR = 5,
+  }: PlaceOptions,
+): Map<string, Placement> {
+  const out = new Map<string, Placement>();
+  const placed: { x0: number; x1: number; y: number }[] = [];
+
+  for (const item of items) {
+    for (const slot of LADDER) {
+      const anchor = slot.side ?? item.anchor;
+      const x = item.cx + slot.dx;
+      const y = item.cy + slot.dy;
+      if (y < minY || y > maxY) continue;
+
+      const [x0, x1] = extent(x, item.width, anchor);
+      if (x0 < minX || x1 > maxX) continue;
+
+      // A 2px horizontal breathing gap: touching labels read as one string.
+      const clash = placed.some(
+        (p) => Math.abs(p.y - y) < rowH && x0 < p.x1 + 2 && x1 > p.x0 - 2,
+      );
+      if (clash) continue;
+
+      // The glyph box for a 12px label sits roughly from y-9 to y+3 around
+      // the baseline. A dot inside that box lands in the middle of a word.
+      // The label's own point is exempt: it is what the label names, and a
+      // beside-slot deliberately sits next to it.
+      const onPoint = points.some(
+        (p) =>
+          !(p.x === item.cx && p.y === item.cy) &&
+          p.x + pointR > x0 &&
+          p.x - pointR < x1 &&
+          p.y + pointR > y - 9 &&
+          p.y - pointR < y + 3,
+      );
+      if (onPoint) continue;
+
+      placed.push({ x0, x1, y });
+      out.set(item.key, { x, y, anchor });
+      break;
+    }
+  }
+  return out;
+}
+
+/// Rendered width of a label, estimated from character count. Deliberately a
+/// little generous: under-estimating width is what lets two labels touch, and
+/// a slightly wide box only costs an occasional extra drop.
+export function labelWidth(text: string, fontSize = 12): number {
+  return text.length * fontSize * 0.55 + 6;
+}


### PR DESCRIPTION
The scatter labels every point above significance 40. That was "a few outliers in the sparse corner" when it was written; the catalog has since filled the band, and roughly two dozen names were being drawn inside one crowded rectangle - overlapping each other, overlapping the dots, and climbing out of the card into the description text above.

## What was actually wrong

Two bugs, not one:

**The stacker gave up.** It lifted a label one row per collision but capped at six lifts and drew the label anyway. So the densest region - exactly the one needing help - got the worst pile.

**Layout ran over the wrong set.** It packed `plottable` (every point) while the chart draws `shown` (after legend and tier filters). Filtering never decluttered: hidden points still reserved space and pushed visible labels off their own dots.

## The replacement

A packer in `src/lib/scatter-labels.ts`, kept out of the component and free of React so it can be tested directly.

- **A ladder of slots: above, below, and beside the point.** Sideways matters more than it sounds. The crowded band runs diagonally, so its points stack vertically at similar x and the free space is left and right rather than overhead. Vertical-only placement kept **7** labels; adding side slots keeps **14**.
- **Dots are obstacles too.** My first attempt cleared label-against-label and then wrote text straight through the scatter - tidy rows with points punched through the middle of words. Fixed, with a test.
- **Bounds on all four sides**, so nothing climbs out of the card again.
- **Drop, never overprint.** One dropped label costs one name; an overprinted one costs every name beneath it. Points stay hover- and click-discoverable either way.
- **Anchor-aware extents**, shared with the renderer via `labelAnchorAt`. Edge labels were being collision-tested as if centred, so they overlapped their neighbours.

Packing order is significance-descending, so when the middle band runs out of room the name that survives is the one a reader came for.

## Verification

Screenshotted `/stats` headlessly **against production data**, not just reasoned about - the hardest case is the top of the scale, and staging has no entry above 70.

Result: 14 labels, none overlapping a label or a dot, Navier-Stokes legible at 87 where headroom is tightest.

- `npm run typecheck` clean, `npm run lint` 0 errors
- 115 tests pass, **15 new**, including both regressions this fixes and the property that side slots recover labels a vertical-only ladder drops

## Manual check after deploy

Open `/stats`, then click through Any / Discovered / Co-developed / Assisted. Label placement should re-pack on each filter and stay clean - that path was broken before and is the one most likely to regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Second commit: "Most significant result per month"

A new chart on `/stats`: the heaviest problem resolved in each month, from the first solve to today.

**Why it earns a card.** Every other time chart on the page counts things, so every one of them rises simply because the catalog grows. This one cannot - a month is worth its best result, so the line moves only when something genuinely bigger lands. It is the only view on the page showing a ceiling rising rather than a pile deepening.

On production data it reads as six records: paper tori → Oddtown mod composite → Nesterov point convergence → sum-product conjecture → Jacobian conjecture → **Navier-Stokes at 87**.

## Decisions worth arguing with

- **Empty months are gaps, not omissions.** The flat early stretch is what gives the recent jumps their meaning; compressing it away would flatter the data.
- **The axis runs to today, not to the last solve.** A chart ending at the last result implies the record ended with it.
- **Candidates count.** A claimed solution under review is still the biggest thing that happened in its month, and the entry page says what it is.
- **Partials and variants are excluded**, for the same reason the age scatter excludes them: a bound improvement has no single moment of resolution.
- **Only record-setting months are labelled.** On a running-maximum chart, every other month is by definition under a line the reader can already see.
- **No time-range toggle**, unlike its siblings. "From the first entry to today" is the point.

## Why the two commits ship together

`PeakChart` reuses the label packer from the first commit. August and September 2026 set records in consecutive months, so without it the labels would overprint exactly where the chart is most interesting.

## Verification

- 13 tests on the bucketing: tie-breaking, gaps, running to today, a solve dated in the future, and the running-maximum properties
- 128 tests pass overall, `npm run typecheck` clean, `npm run lint` 0 errors
- Screenshotted `/stats` headlessly against production data. The first render drew the month labels through the bottoms of the bars: `TimeAxis` wants the baseline **plus 18**, not the baseline, as every sibling chart already knew.

## Manual check after deploy

Hover across the months - the caption under the chart should name each month's result - and click one to confirm it opens the entry.
