### PR TITLE
Release: scatter label fix and most-significant-per-month chart

### DIFF
--- a/scripts/add-alpoge-buckmaster-2026-09-08.ts
+++ b/scripts/add-alpoge-buckmaster-2026-09-08.ts
@@ -1,0 +1,362 @@
+// Adds the three Alpöge-Buckmaster forced-blowup entries, released 8 September
+// 2026: 3D incompressible Euler, inviscid Boussinesq, and IPM.
+//
+// What was read before writing:
+//   - All three papers, downloaded and read: euler.pdf (112pp, Theorem 1.1),
+//     boussinesq.pdf (76pp, and its section 2 "AI statement" in full), and
+//     ipm.pdf (57pp, Theorem 2.1 and the prior-art discussion).
+//   - Buckmaster's public statement (statement.pdf), all four pages.
+//   - The Lean repository tristanbuckmaster/fluid_lean: the file tree, the
+//     three READMEs, and euler-blowup/Challenge.lean in full.
+//   - Fefferman's official Clay problem description, to settle whether any of
+//     this is the Millennium problem. It is not, and the entries say so.
+//
+// The Millennium question, since every reader arriving from social media will
+// ask it. Fefferman's alternatives (C) and (D) DO permit a smooth forcing term
+// obeying rapid space-time decay, so the forced route is a legitimate path to
+// the prize - but only for Navier-Stokes with viscosity nu > 0, and his
+// description closes with: "These problems are also open and very important
+// for the Euler equations (nu = 0), although the Euler equation is not on the
+// Clay Institute's list of prize problems." Euler, Boussinesq and IPM are all
+// outside the prize. Each resultNote states this explicitly.
+//
+// Tiers. Euler and Boussinesq are lean-verified rather than lean-checked: the
+// statement lives in its own Challenge.lean written against plain Mathlib, and
+// leanprover/comparator is configured to type-check that statement
+// independently, confirm the solution inhabits exactly it, restrict axioms to
+// propext/Classical.choice/Quot.sound, and replay the proof. That separation
+// of statement from proof is what tier 1 asks for. IPM has no Lean project in
+// the repository at all, so it takes unreviewed.
+//
+// AI contribution is ai-co-developed for all three, not ai-discovered. The
+// models produced the proofs - the authors say so plainly - but the program is
+// Córdoba and Martínez-Zoroa's, the targets and the fed-in prior work were the
+// authors', and Buckmaster is emphatic in public about where the credit sits.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { Prisma, PrismaClient } from "@prisma/client";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes("--apply");
+
+const LIMITS = new Map<string, number>();
+for (const s of [...EDITABLE_FIELDS, ...CURATOR_FIELDS])
+  if (s.maxLength) LIMITS.set(s.key, s.maxLength);
+
+const STATEMENT_URL = "https://cims.nyu.edu/~tristanb/statement.pdf";
+const LEAN_REPO = "https://github.com/tristanbuckmaster/fluid_lean";
+
+/// The authors' own AI account, quoted from section 2 of the Boussinesq paper.
+/// The Euler paper carries no AI statement and no author line - it was
+/// released before it was ready, which Buckmaster apologises for in public -
+/// so the Euler entry cites this and the public statement instead of
+/// paraphrasing something the Euler paper does not say.
+const AI_STATEMENT =
+  'The Boussinesq paper devotes its section 2 to an "AI statement": "We happily used both Claude and Codex to iterate on our proof. We had, using Claude, our first blowup solution, but not this one, on 8/15/26, and we Lean verified it on 8/22/26. This involved inputting ideas from previous joint work of ours on blowup for the IPM equation following Córdoba-Martínez-Zoroa and a number of other works of ours and others, as well as iteration with the model on various ansätze, eventually leading to blowup in Boussinesq. The first writeup that we produced iterating with Claude was, in our opinion, the worst writeup we had ever seen in the history of mathematics (topped soon after by the writeups for 3d Euler and then for hypodissipative Navier-Stokes)."';
+
+const MODELS = "Claude, Codex with GPT-5.6 Sol";
+const COLLABORATORS = ["Levent Alpöge", "Tristan Buckmaster"];
+
+/// Repeated verbatim on each entry. A reader who arrives from a thread saying
+/// "AI solved a Millennium problem" should be corrected on the entry page
+/// itself, not in a note somewhere else.
+const NOT_CLAY =
+  "Not the Clay Millennium problem: that problem is Navier-Stokes with viscosity, and Fefferman's official description states that the Euler equation \"is not on the Clay Institute's list of prize problems\".";
+
+const commonLinks = (leanDir: string) => [
+  {
+    label: "Lean formalisation, comparator-checked against Challenge.lean",
+    url: `${LEAN_REPO}/tree/main/${leanDir}`,
+    kind: "lean-proof",
+  },
+  {
+    label: "Challenge.lean: the trusted statement, in plain Mathlib",
+    url: `${LEAN_REPO}/blob/main/${leanDir}/Challenge.lean`,
+    kind: "lean-statement",
+  },
+  {
+    label: "Buckmaster's public statement on the work and its release",
+    url: STATEMENT_URL,
+    kind: "announcement",
+  },
+];
+
+type Entry = {
+  slug: string;
+  fields: Record<string, unknown>;
+  links: { label: string; url: string; kind: string }[];
+  /// Names to search for, so a dry run reports any near-duplicate already in
+  /// the catalog before anything is written.
+  dupTerms: string[];
+};
+
+const ENTRIES: Entry[] = [
+  // ------------------------------------------------------------------ Euler
+  {
+    slug: "euler-blowup-smooth-forcing",
+    dupTerms: ["Euler", "blowup", "blow-up"],
+    fields: {
+      name: "Finite-time blowup for the 3D incompressible Euler equations with smooth forcing",
+      shortName: "Euler blowup, smooth force",
+      fieldGroup: "Differential equations",
+      field: "Fluid dynamics; singularity formation for incompressible flow",
+      statement:
+        "Can a solution of the three-dimensional incompressible Euler equations on $\\mathbb R^3$, started from smooth data and driven by a force that is smooth in space and time up to and including the blowup time, lose regularity in finite time? Finite-time singularity formation from genuinely smooth data is the central open question for the equations. Elgindi obtained blowup for $C^{1,\\alpha}$ solutions in 2021, and Córdoba and Martínez-Zoroa built a multiscale program producing forced blowup for related equations with forces of limited regularity, but no construction reached three-dimensional Euler with a space-time smooth force. Note on the forced formulation, since it is easy to misread: alternatives (C) and (D) of Fefferman's Clay problem description do permit a smooth force obeying rapid space-time decay, so forcing is not a dodge and the forced route is a genuine path to the prize. It is a path for Navier-Stokes with viscosity, however, and not for Euler, which Fefferman's description excludes from the prize list.",
+      posedBy:
+        "Classical; the breakdown question is recorded in Fefferman's official Clay problem description, which notes it is open and important for Euler though not itself a prize problem",
+      yearPosed: 2000,
+      solveType: "proved",
+      resolution: "resolved",
+      resolutionMethod: "construction",
+      solveDate: "2026-09-08",
+      model: MODELS,
+      modelMaker: "Anthropic / OpenAI",
+      humanCollaborators: COLLABORATORS,
+      aiContribution: "ai-co-developed",
+      aiRole: `${AI_STATEMENT} Buckmaster's public statement adds that the models used were "Anthropic's Claude, OpenAI's Codex, especially with GPT-5.6 Sol and, more recently, Astra", the last "only used for writeups and auditing our arguments", and that "the first LLM generated proof Levent sent me was the most horrendous I have ever read". He is explicit that the program is not the models': "The credit for the basic idea of this program goes to Diego Córdoba and Luis Martínez-Zoroa... We took their work as a starting point, using Large Language Models to push their program to completion." Co-developed rather than discovered on that account. The Euler paper carries no AI statement of its own.`,
+      verification: "lean-verified",
+      verificationNote:
+        'Formalised in Lean 4 in tristanbuckmaster/fluid_lean (euler-blowup). Checked here on 8 September 2026 by reading the repository: Challenge.lean states the theorem against plain Mathlib and is the only file a reader must trust, Solution.lean derives it from the development, and comparator.json configures leanprover/comparator to type-check the statement independently, confirm the solution inhabits exactly that statement, restrict axioms to propext, Classical.choice and Quot.sound, and replay the proof. Mathlib is pinned by commit; the build is roughly 1,100 modules and the README warns it needs on the order of 100 GB of memory. The Lean statement was read and matches the paper\'s Theorem 1.1, including the divergence of the Beale-Kato-Majda vorticity integral and uniqueness against non-axisymmetric competitors. Not yet peer reviewed: Terence Tao has publicly analysed the result and calls it "a remarkable achievement", but says he is still digesting the proof, so no expert has certified the argument line by line.',
+      resultNote: `Yes. Theorem 1.1: for every $r_0>0$ and $z_0$ there are a time $T_*>0$, a divergence-free axisymmetric $u_0\\in C_c^\\infty$ supported in a fixed solid torus with nonzero swirl and zero meridional velocity, and an axisymmetric force $f\\in C^\\infty(\\mathbb R^3\\times[0,T_*])$ supported in that torus, with a solution smooth on $[0,T_*)$ for which circulation and meridional velocity stay bounded while $\\|\\nabla\\Gamma(t)\\|_\\infty$ and $\\|\\omega(t)\\|_\\infty$ tend to infinity and $\\int_0^{T_*}\\|\\omega(t)\\|_\\infty\\,dt=\\infty$, so the blowup is genuine by Beale-Kato-Majda. It is unique among divergence-free locally space-time Lipschitz solutions with the same data, and competitors need not be axisymmetric. ${NOT_CLAY}`,
+      significance: 70,
+      significanceNote:
+        'The strongest result in this catalog. Finite-time singularity formation for three-dimensional incompressible Euler is one of the central problems of mathematical fluid dynamics, and this settles it in the forced smooth category, one category short of the Clay problem. Terence Tao\'s public assessment is that nothing in principle blocks extending the method to Navier-Stokes and that there is "a non-negligible chance that the forcing term could be eliminated entirely". Below the 80s because the force is essential to the result and its removal is exactly the hard part.',
+      publication: "preprint",
+      sourceUrl: "https://cims.nyu.edu/~tristanb/euler.pdf",
+      sourceName:
+        "Blowup for the Euler equations with smooth forcing (manuscript)",
+      ageNote:
+        'Released 8 September 2026, earlier than the authors intended. Their own chronology: a first blowup solution on 15 August 2026, Lean-verified on 22 August, then weeks spent turning a model-generated argument into prose. Buckmaster calls the Euler writeup "AI slop", apologises for its state, and attributes the early release to outside pressure.',
+      status: "published",
+      reviewReason: "edited",
+    },
+    links: [
+      ...commonLinks("euler-blowup"),
+      {
+        label: "Terence Tao's assessment of the result and the mechanism",
+        url: "https://mathstodon.xyz/@tao/117233527638291447",
+        kind: "discussion",
+      },
+      {
+        label: "Buckmaster's announcement, with all three manuscripts",
+        url: "https://mastodon.social/@tristanbuckmaster/117233413705701198",
+        kind: "announcement",
+      },
+      {
+        label: "Fefferman's official Clay problem description",
+        url: "https://www.claymath.org/wp-content/uploads/2022/06/navierstokes.pdf",
+        kind: "problem-record",
+      },
+    ],
+  },
+
+  // ------------------------------------------------------------- Boussinesq
+  {
+    slug: "boussinesq-blowup-smooth-forcing",
+    dupTerms: ["Boussinesq"],
+    fields: {
+      name: "Finite-time blowup for the inviscid Boussinesq system with smooth forcing",
+      shortName: "Boussinesq blowup, smooth force",
+      fieldGroup: "Differential equations",
+      field: "Fluid dynamics; singularity formation for incompressible flow",
+      statement:
+        "Does the inviscid Boussinesq system on $\\mathbb R^2$ admit finite-time blowup from smooth data with forces that are smooth in both space and time? Córdoba, Laín-Sanclemente and Martínez-Zoroa obtained finite-time singularity for the two-dimensional Boussinesq equation with a force only of class $C^{1,\\sqrt{4/3}-1-\\epsilon}\\cap L^2$, leaving the smooth-force case open.",
+      posedBy:
+        "Diego Córdoba, Antonio Laín-Sanclemente and Luis Martínez-Zoroa, whose multiscale construction reached a force of limited Hölder regularity",
+      yearPosed: 2025,
+      solveType: "proved",
+      resolution: "resolved",
+      resolutionMethod: "construction",
+      solveDate: "2026-09-08",
+      model: MODELS,
+      modelMaker: "Anthropic / OpenAI",
+      humanCollaborators: COLLABORATORS,
+      aiContribution: "ai-co-developed",
+      aiRole: `${AI_STATEMENT} The statement continues that after iterating with Claude and Codex on alternative proof architectures, "leading to several different proofs, we arrived at the current simplified argument, which we then iterated on using Claude and Codex, first 5.6 Sol and then Astra once we had access, to arrive at the current writeup modulo our hand editing", and that intermediate writeups were generally fed to Codex "for simplification, ideation, and iteration". Co-developed rather than discovered: the first blowup solution came from Claude, but the multiscale mechanism is Córdoba and Martínez-Zoroa's and the authors fed in their own earlier IPM work.`,
+      verification: "lean-verified",
+      verificationNote:
+        'Formalised in Lean 4 in tristanbuckmaster/fluid_lean, twice over: boussinesq-blowup carries the general theorem and affinecore the normalised construction with explicit odd initial data. Checked here on 8 September 2026 by reading both READMEs: in each, Challenge.lean is the only file a reader must trust, no other file contains a sorry, the proof rests on no axiom beyond propext, Classical.choice and Quot.sound, and leanprover/comparator is configured to type-check the statement independently and confirm the solution inhabits exactly it. Not peer reviewed. Tao\'s public commentary describes the Boussinesq case as the model case whose amplitude-frequency dynamics reduce to "a remarkably simple ODE", but records that he is still working through the arguments.',
+      resultNote: `Yes. Blowup for the inviscid Boussinesq system on $\\mathbb R^2$ with forces in $C^\\infty(\\mathbb R^2\\times[0,T_*])$ in both equations, supported in one fixed spatial ball, from smooth compactly supported initial temperature and zero initial velocity. The temperature stays bounded while $\\|\\nabla\\theta(t)\\|_\\infty\\to\\infty$ and the vorticity norm has infinite limsup as $t\\uparrow T_*$. The solution is smooth on every closed interval before blowup and unique in a finite-energy Lipschitz class. This lifts the force from barely $C^1$ to fully smooth, and is the construction the Euler paper then builds on. ${NOT_CLAY}`,
+      significance: 45,
+      significanceNote:
+        "A substantial strengthening in its own right, taking the force from a narrow Hölder class to smooth in space and time, and the stepping stone that made the Euler construction possible: the Euler paper develops this paper's two-field wave calculation on a varying background. Below Euler because Boussinesq in two dimensions is a model system rather than the equations of record.",
+      publication: "preprint",
+      sourceUrl: "https://cims.nyu.edu/~tristanb/boussinesq.pdf",
+      sourceName:
+        "Blowup for the Boussinesq equations with smooth forcing (manuscript)",
+      status: "published",
+      reviewReason: "edited",
+    },
+    links: [
+      ...commonLinks("boussinesq-blowup"),
+      {
+        label: "affinecore: the second Lean formalisation, normalised data",
+        url: `${LEAN_REPO}/tree/main/affinecore`,
+        kind: "lean-proof",
+      },
+    ],
+  },
+
+  // -------------------------------------------------------------------- IPM
+  {
+    slug: "ipm-blowup-spacetime-smooth-forcing",
+    dupTerms: ["porous media", "IPM"],
+    fields: {
+      name: "Finite-time blowup for the IPM equation with a uniformly space-time smooth force",
+      shortName: "IPM blowup, space-time smooth force",
+      fieldGroup: "Differential equations",
+      field: "Fluid dynamics; incompressible porous media equation",
+      statement:
+        "Córdoba and Martínez-Zoroa proved finite-time singularity formation for the two-dimensional incompressible porous media equation from smooth initial data with a force smooth in space but merely bounded in time, that is in $L^\\infty_t C^\\infty_x$. Their Remark 1 anticipates joint smoothness in space and time but does not prove it. Can the force be taken uniformly smooth in space and time?",
+      posedBy:
+        "Diego Córdoba and Luis Martínez-Zoroa, Remark 1 of arXiv:2410.22920, where joint space-time smoothness is anticipated but not part of the theorem",
+      yearPosed: 2024,
+      solveType: "proved",
+      resolution: "resolved",
+      resolutionMethod: "construction",
+      solveDate: "2026-09-08",
+      model: MODELS,
+      modelMaker: "Anthropic / OpenAI",
+      humanCollaborators: [
+        "Levent Alpöge",
+        "Tristan Buckmaster",
+        "Matei P. Coiculescu",
+      ],
+      aiContribution: "ai-co-developed",
+      aiRole:
+        'This is the earliest of the three results and the one the authors describe as feeding the others: the Boussinesq AI statement says the Boussinesq work "involved inputting ideas from previous joint work of ours on blowup for the IPM equation following Córdoba-Martínez-Zoroa". Buckmaster\'s public statement covers the whole project: "For most of the past year progress was slow. We worked through the literature and upgraded various preliminary results, up to obtaining finite time blow up for the Incompressible Porous Media equation (with smooth forcing)", using "Anthropic\'s Claude, OpenAI\'s Codex, especially with GPT-5.6 Sol". The IPM paper itself does not break the contribution down per step, and defers a fuller account: "The complete human-readable proofs will be released shortly by the first and second authors, together with an account of the role of artificial intelligence in this work."',
+      verification: "unreviewed",
+      verificationNote:
+        "No independent check. Unlike the Boussinesq and Euler results, this one has no Lean formalisation: tristanbuckmaster/fluid_lean contains projects for Boussinesq (twice) and Euler and none for IPM, confirmed by listing the repository tree on 8 September 2026. The paper is a 57-page manuscript on the second author's university page, not on arXiv and not peer reviewed, and no independent expert reading is on record. It is the most conventional of the three write-ups, being the one the authors had time to prepare.",
+      resultNote: `Yes. Theorem 2.1: there are a smooth odd initial density $\\rho_{in}\\in C^\\infty(\\mathbb T^2)$ of zero spatial mean, an odd force $F\\in C^\\infty([0,1]\\times\\mathbb T^2)$, and a solution smooth on $[0,T]$ for every $T<1$ with $\\rho(t)\\to\\rho_*$ in $C^\\eta$ for every $0\\le\\eta<1$, yet $\\|\\nabla\\rho(t)\\|_\\infty$ and $\\|D_xu_{\\mathbb T}(\\rho(t))\\|_\\infty$ both diverging as $t\\uparrow1$. The advance over Córdoba and Martínez-Zoroa is precisely the force class, from $L^\\infty_t C^\\infty_x$ to uniformly space-time smooth, on the torus rather than the plane. ${NOT_CLAY}`,
+      significance: 25,
+      significanceNote:
+        "The narrowest of the three: the equation already had a smooth-data blowup theorem and what changes is the regularity of the force, a gap its own authors had flagged. It earns its place as a stated open question now closed, and as the result the Boussinesq and Euler constructions were built out of, but it is an increment on an existing theorem rather than a new frontier.",
+      publication: "announcement",
+      sourceUrl: "https://cims.nyu.edu/~tristanb/ipm.pdf",
+      sourceName:
+        "Extending the Córdoba-Martínez-Zoroa IPM blow-up to uniformly space-time smooth forcing (manuscript)",
+      status: "published",
+      reviewReason: "edited",
+    },
+    links: [
+      {
+        label: "Buckmaster's public statement on the work and its release",
+        url: STATEMENT_URL,
+        kind: "announcement",
+      },
+      {
+        label:
+          "Córdoba and Martínez-Zoroa: the theorem extended, and Remark 1's open case",
+        url: "https://arxiv.org/abs/2410.22920",
+        kind: "problem-record",
+      },
+    ],
+  },
+];
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  let bad = 0;
+  for (const e of ENTRIES) {
+    console.log("=".repeat(72));
+    console.log(`### ${e.slug}`);
+    const exists = await prisma.problem.findUnique({
+      where: { slug: e.slug },
+      select: { id: true, status: true },
+    });
+    console.log(`  slug: ${exists ? `EXISTS (${exists.status})` : "free"}`);
+    if (exists) bad++;
+
+    const dups = await prisma.problem.findMany({
+      where: {
+        OR: e.dupTerms.map((t) => ({
+          name: { contains: t, mode: "insensitive" as const },
+        })),
+      },
+      select: { slug: true, status: true },
+    });
+    console.log(
+      `  near-duplicates: ${dups.length ? dups.map((d) => `${d.slug} (${d.status})`).join(", ") : "none"}`,
+    );
+
+    for (const [k, v] of Object.entries(e.fields)) {
+      const lim = LIMITS.get(k);
+      if (typeof v === "string" && lim) {
+        const over = v.length > lim;
+        console.log(
+          `  ${k.padEnd(17)}: ${v.length}/${lim}${over ? `  OVER BY ${v.length - lim}` : ""}`,
+        );
+        if (over) bad++;
+      }
+    }
+    for (const l of e.links) {
+      console.log(`  link             : ${l.label.length}/120  ${l.kind}`);
+      if (l.label.length > 120) bad++;
+    }
+  }
+  if (bad) throw new Error(`${bad} problem(s) - nothing written`);
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+
+  const admin = await prisma.user.findFirst({
+    where: { pseudonym: "Rasmus Lindahl" },
+    select: { id: true, pseudonym: true },
+  });
+  if (!admin) throw new Error("curator not found");
+
+  for (const e of ENTRIES) {
+    const created = await prisma.problem.create({
+      data: {
+        slug: e.slug,
+        ...e.fields,
+        reviewedAt: new Date(),
+        links: { create: e.links.map((l, position) => ({ ...l, position })) },
+      } as unknown as Prisma.ProblemCreateInput,
+      select: { id: true },
+    });
+    await prisma.problemActivity.create({
+      data: {
+        problemId: created.id,
+        userId: admin.id,
+        userName: admin.pseudonym,
+        type: "approved",
+      },
+      select: { id: true },
+    });
+    console.log(`applied: created ${e.slug}`);
+  }
+
+  console.log(
+    `\nAPPLIED - published entries now ${await prisma.problem.count({ where: { status: "published" } })}. Public caches lag until the next deploy; entry pages are right immediately.`,
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/credit-leder-2026-09-08.ts
+++ b/scripts/credit-leder-2026-09-08.ts
@@ -1,0 +1,162 @@
+// Replaces the submitter's paraphrase of the AI role on the percolation entry
+// with the repository's own words, and records the disclosed wall time.
+//
+// This started as "credit the directing human", which turned out to be
+// unnecessary: humanCollaborators already reads ["Justin Leder"], supplied by
+// the submitter. What is left is precision of attribution rather than the
+// presence of it.
+//
+// The name and the role were checked against three first-party places in
+// anthropics/formal-math at the pinned commit rather than taken from the
+// submitter, who is an anonymous account:
+//
+//   NOTICE            "Responsible author and maintainer: Justin Leder. The
+//                     Lean sources in this repository were written by an AI
+//                     system (Anthropic's Claude models) working autonomously
+//                     under his direction."
+//   README.md         "Author. Justin Leder (@jleder3)."
+//   formalization.yaml the human-role and prompting-notes blocks quoted below.
+//
+// Also adds the repository's own guide to the proof as a link. Its README
+// calls summary.pdf "the guide to the proof" and warns that the library
+// docstrings "were machine-written as working notes... they are not an
+// exposition", so pointing a reader at the summary rather than at the sources
+// is the useful thing to do.
+//
+// ageNote records the wall time, because a problem open since 1960 in the hard
+// dimensions and closed in about a week of compute is the fact a reader will
+// want, and it is disclosed in the repository rather than inferred.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { Prisma, PrismaClient } from "@prisma/client";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { texToHtml } from "../src/components/TeX";
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes("--apply");
+const LINK_LABEL_MAX = 120;
+
+const LIMITS = new Map<string, number>();
+for (const s of [...EDITABLE_FIELDS, ...CURATOR_FIELDS])
+  if (s.maxLength) LIMITS.set(s.key, s.maxLength);
+
+const SLUG =
+  "absence-of-critical-bernoulli-bond-percolation-on-z-d-in-every-dimension-d-2";
+const PIN = "795efb86f191735c5481675763537cfb4ff37e55";
+const BASE = `https://github.com/anthropics/formal-math/blob/${PIN}/percolation`;
+
+const EDITS: Record<string, unknown> = {
+  aiRole:
+    'The repository\'s own provenance section: the Lean sources, "definitions, statements and proofs, together with Challenge.lean, Solution.lean and the metadata", "were written by an AI system (Anthropic\'s Claude models) working autonomously under the direction of Justin Leder; no human wrote or edited the Lean code." Its formalization.yaml records the split: "Discovery, informal proof and Lean formalization were all produced by the AI system operating autonomously. Human role (Justin Leder): problem selection, direction, reading of the statement file and metadata, and responsibility for this submission", the author having "posed the problem, set the acceptance standard (kernel-checked proof with the standard axioms, plus adversarial review of the statements) and directed priorities." The same file states that the only review so far was by AI systems, adversarial reads of the formal statements and of the proof chain against the cited literature, and the README asks readers to satisfy themselves that Challenge.lean states the intended theorem rather than relying on the kernel for that - which is the audit recorded under verification here.',
+
+  ageNote:
+    "The repository discloses about one week of wall time in August 2026, on cloud CPU machines for Lean elaboration plus API inference, with spend not tracked. The problem it closes had been open in dimensions 3 to 10 since Harris settled the planar case in 1960.",
+};
+
+const LINKS = [
+  {
+    label: "summary.pdf: the repository's own guide to the proof",
+    url: `${BASE}/summary.pdf`,
+    kind: "paper",
+  },
+  {
+    label: "formalization.yaml: provenance, cost and disclosed divergences",
+    url: `${BASE}/formalization.yaml`,
+    kind: "other",
+  },
+];
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const cur = await prisma.problem.findUnique({
+    where: { slug: SLUG },
+    select: {
+      id: true,
+      status: true,
+      humanCollaborators: true,
+      aiRole: true,
+      ageNote: true,
+      _count: { select: { links: true } },
+    },
+  });
+  if (!cur) throw new Error(`not found on ${db}: ${SLUG}`);
+  console.log(`status: ${cur.status}`);
+  console.log(
+    `humanCollaborators before: ${JSON.stringify(cur.humanCollaborators)}`,
+  );
+  console.log(`ageNote before           : ${cur.ageNote ?? "(empty)"}`);
+  console.log(`aiRole before            : ${cur.aiRole?.slice(0, 90)}...\n`);
+
+  let bad = 0;
+  for (const [k, v] of Object.entries(EDITS)) {
+    const lim = LIMITS.get(k);
+    if (typeof v === "string" && lim) {
+      const over = v.length > lim;
+      console.log(
+        `  ${k.padEnd(19)}: ${v.length}/${lim}${over ? "  OVER" : ""}`,
+      );
+      if (over) bad++;
+      // aiRole and ageNote both render through <TeX>, so a stray "$" would
+      // either swallow prose or produce a katex-error span.
+      if (v.includes("$")) {
+        const html = texToHtml(v);
+        if (html.includes("katex-error")) {
+          console.log("      katex-error");
+          bad++;
+        }
+      }
+    } else {
+      console.log(`  ${k.padEnd(19)}: ${JSON.stringify(v)}`);
+    }
+  }
+  for (const l of LINKS) {
+    console.log(
+      `  link               : ${l.label.length}/${LINK_LABEL_MAX}  ${l.kind}`,
+    );
+    if (l.label.length > LINK_LABEL_MAX) bad++;
+  }
+  if (bad) throw new Error(`${bad} problem(s) - nothing written`);
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+
+  const n = cur._count.links;
+  await prisma.problem.update({
+    where: { id: cur.id },
+    data: {
+      ...EDITS,
+      links: { create: LINKS.map((l, i) => ({ ...l, position: n + i })) },
+    } as unknown as Prisma.ProblemUpdateInput,
+    select: { id: true },
+  });
+  console.log(
+    "APPLIED. The entry page is cached under problem-<slug> with cacheLife hours, so the public page catches up within an hour or on the next deploy.",
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/fix-percolation-tex-2026-09-08.ts
+++ b/scripts/fix-percolation-tex-2026-09-08.ts
@@ -1,0 +1,124 @@
+// The percolation entry came in with ASCII mathematics - "Z^d", "theta(p)",
+// "d >= 2" - so the entry page showed them literally instead of typeset.
+// This rewrites the fields that are actually TeX-rendered.
+//
+// Which fields may carry TeX, checked in the components rather than assumed:
+//   name, statement, resultNote, verificationNote, aiRole  -> <TeX>, safe.
+//   significanceNote -> <StarNote text={...}> which calls renderBold, NOT
+//     TeX. A "$" here would render as a literal dollar sign, so this field is
+//     left in Unicode.
+//   shortName -> deTeX in cards and meta titles, texToHtml in RelatedEntries,
+//     but printed RAW in FrontierMembership, the frontiers page and stats. It
+//     therefore cannot carry TeX either, and gets Unicode instead.
+//
+// verificationNote is left alone on purpose: its mathematics is Lean source
+// being quoted (SimpleGraph.hasse, Fin d → ℤ, Iff.rfl, propext), and setting
+// code as TeX would be wrong, not prettier.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { PrismaClient } from "@prisma/client";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { texToHtml } from "../src/components/TeX";
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes("--apply");
+
+const LIMITS = new Map<string, number>();
+for (const s of [...EDITABLE_FIELDS, ...CURATOR_FIELDS])
+  if (s.maxLength) LIMITS.set(s.key, s.maxLength);
+
+const SLUG =
+  "absence-of-critical-bernoulli-bond-percolation-on-z-d-in-every-dimension-d-2";
+
+const EDITS: Record<string, string> = {
+  name: "Absence of critical Bernoulli bond percolation on $\\mathbb Z^d$ in every dimension $d \\ge 2$",
+
+  // Unicode, not TeX: this string is printed raw in several places.
+  shortName: "Critical percolation: θ(p_c) = 0",
+
+  statement:
+    "For nearest-neighbour Bernoulli bond percolation on $\\mathbb Z^d$, let $\\theta(p)$ be the probability that the open cluster of the origin is infinite, and let $p_c$ be the critical parameter. Is $\\theta(p_c) = 0$ for every integer $d \\ge 2$?",
+
+  resultNote:
+    "Claims $\\theta(p_c) = 0$ for every $d \\ge 2$, by proving Kozma-Nitzan Conjecture 3 and its reduction to critical percolation. The previously open dimensions $3 \\le d \\le 10$ are included. The formal statement concerns vanishing at $p_c$; continuity of $\\theta$ on the whole interval is a classical consequence rather than the formal target. No claim is intended concerning site percolation or other lattices.",
+};
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const cols = Object.keys(EDITS)
+    .map((c) => `"${c}"`)
+    .join(", ");
+  const [before] = await prisma.$queryRawUnsafe<Record<string, string>[]>(
+    `SELECT ${cols} FROM "Problem" WHERE slug = $1`,
+    SLUG,
+  );
+  if (!before) throw new Error(`not found on ${db}: ${SLUG}`);
+
+  let bad = 0;
+  for (const [k, v] of Object.entries(EDITS)) {
+    const lim = LIMITS.get(k);
+    const over = lim ? v.length > lim : false;
+    console.log(
+      `--- ${k}${lim ? `  ${v.length}/${lim}` : ""}${over ? "  OVER" : ""}`,
+    );
+    console.log(`  before: ${before[k]}`);
+    console.log(`  after : ${v}`);
+    if (over) bad++;
+
+    // Every field that carries TeX must render without a KaTeX error, and the
+    // formulas must actually be recognised as formulas. A silent
+    // katex-error span is how a "$" typo ships.
+    if (v.includes("$")) {
+      const html = texToHtml(v);
+      const spans = html.match(/class="katex"/g)?.length ?? 0;
+      const err = html.includes("katex-error");
+      console.log(`  katex : ${spans} formula(s)${err ? "  ERROR" : ""}`);
+      if (err || spans === 0) bad++;
+    } else if (/\^|_[a-z]|>=|<=/.test(v)) {
+      console.log(
+        "  note  : no TeX here by design (rendered raw or bold-only)",
+      );
+    }
+    console.log();
+  }
+  if (bad) throw new Error(`${bad} problem(s) - nothing written`);
+
+  if (!APPLY) {
+    console.log("DRY RUN - pass --apply to write");
+    return;
+  }
+
+  await prisma.problem.update({
+    where: { slug: SLUG },
+    data: EDITS as never,
+    select: { id: true },
+  });
+  console.log(
+    "APPLIED. Public caches lag until the next deploy; the entry page is right immediately.",
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/review-2026-09-08-b.ts
+++ b/scripts/review-2026-09-08-b.ts
@@ -1,0 +1,283 @@
+// Review of the two submissions pending on the evening of 8 September 2026.
+// Both approved.
+//
+// PERCOLATION. This is the largest claim the catalog has taken, so it was
+// checked at four levels rather than read:
+//
+//   1. Statement fidelity. Challenge.lean read line by line against Grimmett
+//      §§1.3-1.4. The lattice is SimpleGraph.hasse on Fin d → ℤ, whose
+//      symmetrised covering relation is exactly nearest-neighbour adjacency;
+//      the measure is Mathlib's ProbabilityTheory.setBernoulli on G.edgeSet;
+//      the cluster is reachability in fromEdgeSet; theta is the measure of
+//      {|C(0)| = ∞}; p_c is inf {p | theta p > 0} with an explicitly declared
+//      convention for the empty case. The compared claim is theta(p_c) = 0.
+//   2. What setBernoulli actually means, read from Mathlib source rather than
+//      taken from the docstring in the submission: "the measure on Set ι such
+//      that each element of u is taken with probability p, and the elements
+//      outside of u are never taken". With u = G.edgeSet that is Bernoulli
+//      bond percolation. This was the last place a faithful-looking statement
+//      could have been quietly wrong.
+//   3. Smuggled hypotheses, the failure mode that demoted the Erdős-Borwein
+//      entry earlier today: an unproven input passed as a theorem argument is
+//      neither a sorry nor an axiom. Impossible here. percolation_continuity
+//      takes only (d : ℕ) and (2 ≤ d), the transport `bridge` is Iff.rfl, and
+//      comparator.json compares exactly those theorem names with only
+//      propext, Quot.sound, Classical.choice permitted.
+//   4. Counted rather than trusted: across all 251 files, no sorry outside
+//      the two deliberate placeholders in Challenge.lean, zero axiom
+//      declarations, zero native_decide, zero unsafe/implemented_by. Their
+//      AUDIT.md's counts matched mine. Percolation/Literature/ formalises the
+//      classical toolkit (Harris, Kesten, RSW, Russo, planar duality,
+//      Burton-Keane, Grimmett-Marstrand, slab criticality, sharpness,
+//      uniqueness) rather than assuming it.
+//
+// Not done: the build itself. Their run needed a 128-core node and Mathlib
+// from source, which is not reproducible here, so "the kernel accepted this"
+// rests on their audit record - which was accurate everywhere I could test it.
+//
+// Kalai is a report, not an endorsement: "If verified, this is a remarkable
+// breakthrough", "not yet an official Claude document", "we still need to
+// verify if the formalisation is done correctly". So Candidate, and the
+// extraordinary-claims rule is satisfied through formal verification rather
+// than expert review.
+//
+// The submitter is an anonymous account created three minutes before
+// submitting, with no other history and an unverified email. That changes
+// nothing: they are a courier for a first-party artifact in Anthropic's own
+// repository, and nothing in the entry rests on their word. They are not
+// credited, and the sourceUrl is repointed from the mutable main branch to
+// the commit the submitter pinned in their note.
+//
+// DEPTH THREE. The sequel invited in this morning's review of the depth-two
+// entry, filed as its own entry exactly as asked, with depth two linked as
+// predecessor rather than as verification. Same tier and status as its
+// predecessor, one point lower in significance because the architecture it
+// uses was established there.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { PrismaClient } from "@prisma/client";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { MESSAGE_MAX } from "../src/lib/messages";
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes("--apply");
+const LINK_LABEL_MAX = 120;
+
+const LIMITS = new Map<string, number>();
+for (const s of [...EDITABLE_FIELDS, ...CURATOR_FIELDS])
+  if (s.maxLength) LIMITS.set(s.key, s.maxLength);
+
+const PIN = "795efb86f191735c5481675763537cfb4ff37e55";
+const REPO = `https://github.com/anthropics/formal-math/tree/${PIN}/percolation`;
+
+type LinkIn = { label: string; url: string; kind: string };
+type Decision = {
+  slug: string;
+  action: "approve" | "reject";
+  reason: string;
+  message: string;
+  edits?: Record<string, unknown>;
+  links?: LinkIn[];
+};
+
+const DECISIONS: Decision[] = [
+  {
+    slug: "absence-of-critical-bernoulli-bond-percolation-on-z-d-in-every-dimension-d-2",
+    action: "approve",
+    reason: "other",
+    message: `Listed, at the top of the catalog. Thank you for sending it, and for the framing: asking to be reviewed as a candidate rather than as an established resolution is what made this quick to act on.
+
+Two changes, one up and one sideways.
+
+Verification is now Lean-verified rather than Lean-checked. You were modest, and I disagree with you. The top tier wants the proof kernel-checked and the statement anchored by an audited correspondence, and both hold. I read Challenge.lean against Grimmett's definitions: hasse on Fin d → ℤ is exactly nearest-neighbour adjacency, setBernoulli on the edge set does mean each edge open independently with probability p (checked at Mathlib source, not from your docstring), theta is the measure of the infinite-cluster event, and p_c is the infimum form with its empty-set convention declared out loud.
+
+The check that mattered most: percolation_continuity takes only a dimension and 2 ≤ d, bridge is Iff.rfl, and comparator compares exactly those theorem names under the three standard axioms. So no unproven input can enter as a theorem argument, which is the failure mode a sorry count and an axiom audit both miss. Across 251 files my own counts found no sorry outside the two deliberate placeholders, no axiom declaration, no native_decide and no unsafe, matching your AUDIT.md everywhere I could test it.
+
+What I did not do is rebuild it: a 128-core node and Mathlib from source is beyond what I can reproduce, so kernel acceptance rests on your audit record.
+
+Status stays Candidate, matching your own request and Kalai's position: "if verified, this is a remarkable breakthrough", "we still need to verify if the formalisation is done correctly".
+
+I also repointed the source from the main branch to the commit you pinned in your note. An entry this size should cite something immutable.
+
+Significance 78. For calibration: a typical Erdős problem is near 10, and the previous highest entry was 70.`,
+    edits: {
+      verification: "lean-verified",
+      resolution: "candidate",
+      significance: 78,
+      sourceUrl: REPO,
+      sourceName:
+        "anthropics/formal-math, percolation (Lean 4 development, pinned commit 795efb8)",
+      verificationNote:
+        'Formalised in Lean 4 in anthropics/formal-math at commit 795efb8. Audited here on 8 September 2026 at four levels. Statement: Challenge.lean read against Grimmett §§1.3-1.4 - the lattice is SimpleGraph.hasse on Fin d → ℤ, whose symmetrised covering relation is nearest-neighbour adjacency; the measure is ProbabilityTheory.setBernoulli on the edge set, whose Mathlib definition was read at source and does mean each edge open independently with probability p; theta is the measure of {|C(0)| = ∞}; p_c is inf {p | theta p > 0} with the empty-case convention declared. Structure: percolation_continuity takes only a dimension and 2 ≤ d, the transport is Iff.rfl, and comparator.json compares exactly the two theorem names permitting only propext, Quot.sound and Classical.choice - so no unproven input can enter as a theorem argument. Counts taken independently across all 251 files and 97,574 lines: no sorry outside the two deliberate placeholders, zero axiom declarations, zero native_decide, zero unsafe. Percolation/Literature/ formalises the classical toolkit rather than assuming it. Not rebuilt here: their run needed a 128-core node and Mathlib from source, so kernel acceptance rests on their audit record, which matched every count I checked. No mathematician has read the argument. Gil Kalai reported it on 3 September with explicit caveats, writing "if verified, this is a remarkable breakthrough" and "we still need to verify if the formalisation is done correctly".',
+      significanceNote:
+        'Duminil-Copin lists this as Conjecture 1 of "Sixty years of percolation", his 2018 ICM survey. Known for d = 2 since Harris and Kesten and for d ≥ 11 by lace expansion since Hara-Slade 1990, it resisted in dimensions 3 to 10 for thirty-five years, precisely because neither planar duality nor the lace expansion reaches them. Resolved for every d ≥ 2 with no hypothesis beyond the dimension. Placed just below the Collatz band: a central problem of probability settled completely, held back only by the fact that no human has yet read the argument.',
+    },
+    links: [
+      {
+        label: "Challenge.lean: the trusted statement, in plain Mathlib",
+        url: `https://github.com/anthropics/formal-math/blob/${PIN}/percolation/Challenge.lean`,
+        kind: "lean-statement",
+      },
+      {
+        label: "AUDIT.md: their build, axiom and comparator record",
+        url: `https://github.com/anthropics/formal-math/blob/${PIN}/percolation/AUDIT.md`,
+        kind: "lean-proof",
+      },
+      {
+        label: "Gil Kalai's report, with his caveats",
+        url: "https://gilkalai.wordpress.com/2026/09/03/amazing-there-is-no-percolation-at-the-critical-probability-in-all-dimensions-solved-by-ai-via-a-conjecture-of-gady-kozma-and-shahaf-nitzan/",
+        kind: "discussion",
+      },
+    ],
+  },
+
+  {
+    slug: "exact-rank-and-smith-profile-of-affine-incidence-over-mathbb-z-p-3-mathbb-z",
+    action: "approve",
+    reason: "other",
+    message: `Listed. This is exactly what I asked for this morning, filed exactly as asked: its own entry for the next parameter case, with depth two linked as predecessor work rather than as verification, and Partial and Unreviewed both retained without an argument for a higher rung. Reviewers notice when a submitter does that.
+
+Significance 7, one below the depth-two entry's 8. Not a criticism: the depth-two paper had to build the maximal-order and depth-transition framework, and depth three applies an architecture that already exists. A sequel in a parameterized family is worth slightly less than the case that opened it.
+
+One thing to think about before a depth four. Consecutive cases of a parameterized problem are separate results while each needs a new idea, and become one result the moment a general argument exists. If the depth-three method suggests how to handle arbitrary k, that general theorem is worth far more than the individual cases and would supersede both of these entries. Worth aiming at.`,
+    edits: {
+      significance: 7,
+      significanceNote:
+        "The next parameter case of the Łaba-Trainor rank question, settled exactly for the depth-three plane. A point below its predecessor because the framework it applies was built there; the general problem for arbitrary depth and dimension remains open.",
+    },
+  },
+];
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const curator = await prisma.user.findFirst({
+    where: { pseudonym: "Rasmus Lindahl" },
+    select: { id: true, pseudonym: true },
+  });
+
+  let bad = 0;
+  for (const d of DECISIONS) {
+    const cur = await prisma.problem.findUnique({
+      where: { slug: d.slug },
+      select: { id: true, status: true, name: true },
+    });
+    if (!cur) throw new Error(`not found on ${db}: ${d.slug}`);
+    if (cur.status !== "pending")
+      throw new Error(`${d.slug} is ${cur.status}, not pending`);
+
+    console.log(
+      `${d.action === "reject" ? "DECLINE" : "APPROVE"}  ${cur.name.slice(0, 58)}`,
+    );
+    console.log(
+      `  message : ${d.message.length}/${MESSAGE_MAX}${d.message.length > MESSAGE_MAX ? "  OVER" : ""}`,
+    );
+    if (d.message.length > MESSAGE_MAX) bad++;
+    for (const [k, v] of Object.entries(d.edits ?? {})) {
+      const lim = LIMITS.get(k);
+      if (typeof v === "string" && lim) {
+        const over = v.length > lim;
+        console.log(
+          `  ${k.padEnd(17)}: ${v.length}/${lim}${over ? `  OVER BY ${v.length - lim}` : ""}`,
+        );
+        if (over) bad++;
+      } else {
+        console.log(`  ${k.padEnd(17)}: ${JSON.stringify(v).slice(0, 70)}`);
+      }
+    }
+    for (const l of d.links ?? []) {
+      console.log(
+        `  link             : ${l.label.length}/${LINK_LABEL_MAX}  ${l.kind}`,
+      );
+      if (l.label.length > LINK_LABEL_MAX) bad++;
+    }
+  }
+  if (bad) throw new Error(`${bad} limit violation(s)`);
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+  if (!curator) throw new Error("curator not found on this database");
+
+  for (const d of DECISIONS) {
+    const cur = await prisma.problem.findUnique({
+      where: { slug: d.slug },
+      select: {
+        id: true,
+        submittedById: true,
+        _count: { select: { links: true } },
+      },
+    });
+    if (!cur) throw new Error(`vanished: ${d.slug}`);
+    const n = cur._count.links;
+
+    await prisma.$transaction([
+      prisma.problem.update({
+        where: { id: cur.id },
+        data: {
+          ...(d.edits ?? {}),
+          ...(d.links?.length
+            ? {
+                links: {
+                  create: d.links.map((l, i) => ({ ...l, position: n + i })),
+                },
+              }
+            : {}),
+          status: d.action === "approve" ? "published" : "rejected",
+          reviewedAt: new Date(),
+          reviewMessage: d.message,
+          reviewReason: d.reason,
+        } as never,
+      }),
+      prisma.directMessage.create({
+        data: {
+          userId: cur.submittedById!,
+          senderId: curator.id,
+          senderName: curator.pseudonym,
+          kind: "decision",
+          reason: d.reason,
+          body: d.message.slice(0, MESSAGE_MAX),
+          problemId: cur.id,
+        },
+      }),
+      prisma.problemActivity.create({
+        data: {
+          problemId: cur.id,
+          userId: curator.id,
+          userName: curator.pseudonym,
+          type: d.action === "approve" ? "approved" : "rejected",
+        },
+      }),
+    ]);
+    console.log(`applied: ${d.action} ${d.slug}`);
+  }
+
+  console.log(
+    "\nAPPLIED. Public caches lag until the next deploy; entry pages are right immediately.",
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/review-2026-09-08.ts
+++ b/scripts/review-2026-09-08.ts
@@ -1,0 +1,456 @@
+// Review of the eight submissions pending on 8 September 2026.
+//
+// What was checked, per submission:
+//   - Sphere packing (Simkin): Klartag's c*d^2*2^-d confirmed as the current
+//     all-dimensional state of the art (Quanta coverage, Kalai and Ellenberg
+//     posts, arXiv 2606.13313 exposition). The claim is an unbounded
+//     improvement ON that bound, with no expert review and no formalization.
+//   - Depth-two affine incidence (Babanskyy): all three cited arXiv papers
+//     fetched and confirmed real and as described - Laba-Trainor 2403.05719
+//     records the residue-ring rank question, Dvir 2604.25822 is the later
+//     bounds paper. Prior art is accurately identified.
+//   - YAH arctic obstruction: read the submitter's own scope statement, which
+//     says the subquestion "was not separately posed in the cited paper" and
+//     that the scalar lemma alone is routine. YAH 2105.14697 confirmed real.
+//   - f(732): OEIS baseline and the Erdos Frontier Atlas P302 gap are as
+//     described; the Lean uses bv_decide with its LRAT checker axiom, so the
+//     submitter's own lean-checked tier is the right one and stays.
+//   - Erdos-Borwein: PrimeInputs.lean read directly. The two hypotheses are
+//     AGP (Alford-Granville-Pomerance, in Vandehey's Proposition 2.1 form) and
+//     a standard PNT consequence on primes in (L, 2L). Both are PUBLISHED
+//     theorems, not conjectures, so the mathematics is conditional only on
+//     known results - but they are hypotheses of the Lean theorem, and the
+//     statement has no independent anchor, so the tier drops one rung.
+//   - Measures on partial orders: arXiv 2609.02021 fetched. Author is Andrew
+//     Snowden and the comments field reads "ChatGPT was used to obtain many
+//     arguments. The writing was done entirely by the author." The submission
+//     describes this accurately.
+//   - Both Gilburg entries: repository tree listed. The shared 96-file
+//     SierpinskiFormal directory is a common library (the name is inherited
+//     from an earlier project, not evidence of a copied proof); each entry has
+//     genuine theorem-specific modules. mortality/FiniteMortalityBound.lean
+//     read in full: exists_short_zero_word_of_finite_real_monoid states
+//     exactly the claimed 2^(n-1) + (2^(n-1)-1)*n(n+1)/2 bound under the
+//     finite-word-range hypothesis, with no sorry and no axiom declarations,
+//     and Audit.lean prints axioms for each endpoint. Neither statement is
+//     anchored to a canonical tracker, so neither earns tier 1.
+//
+// Frontier check: none of these is a tracked quantity with a direction. The
+// sphere-packing claim WOULD be, if it were ever admitted.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { PrismaClient } from "@prisma/client";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { MESSAGE_MAX } from "../src/lib/messages";
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes("--apply");
+const LINK_LABEL_MAX = 120;
+
+const LIMITS = new Map<string, number>();
+for (const s of [...EDITABLE_FIELDS, ...CURATOR_FIELDS])
+  if (s.maxLength) LIMITS.set(s.key, s.maxLength);
+
+type LinkIn = { label: string; url: string; kind: string };
+type Decision = {
+  slug: string;
+  action: "approve" | "reject";
+  reason: string;
+  message: string;
+  edits?: Record<string, unknown>;
+  links?: LinkIn[];
+};
+
+const DECISIONS: Decision[] = [
+  // ---------------------------------------------------------------- 1. HOLD
+  // The extraordinary claims rule is explicit that a claim of this kind waits
+  // for expert review or formal verification, and is not published as a
+  // Candidate either. Klartag's bound is a headline result of the last two
+  // years; an unbounded improvement on it, from a GitHub PDF whose only checks
+  // are the same model family reviewing itself, is exactly the case the rule
+  // was written for. This is a hold on the evidence, not a verdict on the
+  // mathematics, and the message says so.
+  {
+    slug: "an-all-dimensional-improvement-for-lattice-sphere-packing",
+    action: "reject",
+    reason: "other",
+    message: `Thank you for this, and for the unusually careful framing - flagging it as a proof candidate, naming the Klartag and Abuya-Gargava-Zhao baselines correctly, and stating plainly that no specialist has reviewed it. That is the right way to send something like this.
+
+I am holding it rather than listing it, and I want to be exact about why, because it is not a judgement on the mathematics.
+
+The catalog has an explicit rule for claims of this class: famous problems, and problems with decades of failed attempts, wait for expert review or formal verification before being listed - and specifically may not be listed as Candidates in the meantime. The all-dimensional lower bound for lattice sphere packing is squarely in that class. Klartag's c*d^2*2^-d is a headline result of the last two years, and an unbounded multiplicative improvement on it would be significant news in the area. The rule exists so that the catalog is not the first place such news appears.
+
+What would change the answer, either one being enough:
+
+1. A named specialist in lattice packings or high-dimensional convex geometry reads the manuscript and says it holds. That moves it to Independently expert-verified and it goes straight in.
+2. A Lean formalization of the main theorem that compiles, so the bound is machine-checked rather than argued in prose.
+
+Two smaller things that would help regardless. Posting to arXiv gives the work a citable record and a version history, which matters for a priority claim. And the phrase "additional model-based review" is doing a lot of work in the current write-up: same-family models checking each other correlate their errors, so it is worth stating separately from human checking rather than alongside it.
+
+Please do resubmit when either of those two conditions is met. I will look again promptly.`,
+  },
+
+  // ------------------------------------------------------------- 2. APPROVE
+  // Passes the inclusion test cleanly: Laba-Trainor recorded the question as
+  // open, this settles the (k,n) = (2,2) case exactly, and the AI is
+  // substantively in the loop. Not extraordinary - a two-year-old technical
+  // question in finite geometry. Unreviewed is the honest tier and the
+  // submitter chose it themselves.
+  {
+    slug: "exact-rank-and-smith-profile-of-affine-incidence-over-mathbb-z-p-2-mathbb-z",
+    action: "approve",
+    reason: "other",
+    message: `Listed. Thank you - this is a well-made submission.
+
+Three things it got right that reviewers notice. You identified the open question in the literature rather than posing your own, and I checked all three references: Laba-Trainor (arXiv:2403.05719) does record the residue-ring point-hyperplane rank question as open, and Dvir (arXiv:2604.25822) is the later bounds paper you say it is. You picked Unreviewed yourself instead of arguing for a higher tier off the back of your own test suite. And holding the depth-three sequel until this was reviewed was the right call.
+
+It is listed as a Partial result, since the exact rank is settled for (k,n) = (2,2) while the general parameterized problem stays open, which is how you described it.
+
+One note on the write-up, since it applies to the sequel too. The reproducibility work - clean replays, the 59-test suite, adversarial passes within the same workflow - establishes that the artifact is internally consistent and re-runnable. It is not evidence about the mathematics, because a model checking its own output correlates its errors. Your verification note already says this. Keeping that separation as crisp in the sequel will serve you well.
+
+On depth three: send it as its own entry. Consecutive special cases of a parameterized problem are separate results, not an update to this one.`,
+    edits: {
+      significance: 8,
+      significanceNote:
+        "A technical question recorded as open by Laba and Trainor in 2024, settled exactly for the depth-two plane. Specialized but genuine: the full Smith profile is more than the rank the question asked for.",
+    },
+  },
+
+  // -------------------------------------------------------------- 3. DECLINE
+  // Fails the inclusion test on the submitter's own account: the subquestion
+  // was not posed in the cited paper. They invited exactly this answer.
+  {
+    slug: "yah-mixed-base-collatz-system-scalar-arctic-first-step-obstruction-2",
+    action: "reject",
+    reason: "no-open-question",
+    message: `Thank you for this, and for asking directly to be declined if the restricted result did not clear the bar. That kind of framing makes a reviewer's job easy and I would rather say so than let it pass unremarked.
+
+Declining, and essentially on the grounds you set out yourself. The inclusion test is a precisely stated open question whose answer is now a proved or disproved theorem. Your own scope statement says the exact scalar subquestion "was not separately posed in the cited paper", that no separately named conjecture was solved, and that the full scalar lemma alone is routine. The open direction that Yolcu-Aaronson-Heule genuinely raise in section 6 is much broader than what is settled here, and a self-posed restriction of it is not the same object.
+
+None of that says the work is bad. The certificate package is careful, the Farkas and RUP replays are real artifacts, and the claim registry with unresolved bridges listed separately is better hygiene than most submissions show.
+
+What would qualify: settling the section 6 direction itself, or a restriction of it that YAH or a later paper states as a question. If you get to dimension two, or to another carrier where the obstruction still holds, that starts to look like an answer to something someone asked rather than to something you scoped.`,
+  },
+
+  // ------------------------------------------------------------- 4. APPROVE
+  // Thin but sound. The quantity is tracked (OEIS A390395 and the Atlas's
+  // P302 view), the theorem is real and Lean-compiled, the tier is honestly
+  // self-assigned at lean-checked because bv_decide brings the LRAT axiom,
+  // and the dependence on the external f(731) baseline is disclosed. Low
+  // significance is the right way to record a small true thing.
+  {
+    slug: "reciprocal-triple-free-sets-the-finite-plateau-at-732",
+    action: "approve",
+    reason: "other",
+    message: `Listed, as a Partial result at low significance.
+
+This is a small result and you presented it as one, which is why it goes in. The quantity is tracked - OEIS A390395 plus the Frontier Atlas P302 view - so it is not a record on an untracked quantity, which is the exclusion that catches most submissions of this shape. The isolated-component argument is a real theorem, not a search report.
+
+You also chose the correct tier without being asked. bv_decide brings its native LRAT checker axiom, so this is Lean-checked rather than Lean-verified, and you said so along with the fact that the f(731) = 606 baseline is external OEIS data rather than a formal theorem here. Both disclosures are why the entry can be trusted at the tier it claims.
+
+Significance is set to 4. For calibration: a typical Erdos problem sits near 10 and machine-generated conjectures near 5, so a single further term of a finite table under one of them lands where it lands. That is a scale, not a criticism.
+
+If the elementary component argument turns out to be folklore, tell me and I will add a note. Priority on a step this small is not worth a dispute, but the record should be accurate.`,
+    edits: {
+      significance: 4,
+      significanceNote:
+        "One further term of a tracked finite table under Erdos problem 302. The theorem is real and the argument is structural rather than a search, but the asymptotic problem is untouched.",
+    },
+  },
+
+  // ------------------------------- 5. APPROVE, with the tier brought down
+  // The submission claimed lean-verified/resolved. Reading PrimeInputs.lean
+  // settles what "two prime-distribution estimates" means: AGP in Vandehey's
+  // Proposition 2.1 form, and a standard PNT consequence. Both are published
+  // theorems, so this is NOT conditional on conjectures - an important
+  // distinction, and better than the vague submitted note suggested. But they
+  // are hypotheses of the Lean theorem rather than formalized, and the
+  // statement has no canonical anchor, so tier 1 does not hold. Candidate,
+  // per its definition: full solution claimed, publicly checkable, review
+  // pending.
+  {
+    slug: "the-erdos-borwein-constant-is-2-dense",
+    action: "approve",
+    reason: "other",
+    message: `Listed, with two fields changed. Thank you for sending it, and for linking the earlier entry it builds on.
+
+I read lean/ErdosBorwein/PrimeInputs.lean rather than take the summary as given, and it is worth telling you what I found, because it is better news than your own write-up implied. The two hypotheses are AGP - the Alford-Granville-Pomerance estimate in Vandehey's Proposition 2.1 form - and a standard prime number theorem consequence bounding primes in (L, 2L). Both are published theorems. So the result is not conditional on conjectures, only on known results that are not in Mathlib yet. Your note said "two explicitly stated prime-distribution estimates", which a reader could easily take the wrong way. I have rewritten it to name them.
+
+Two changes:
+
+Verification is now Lean-checked, statement unaudited rather than Lean-verified. The top tier needs the proof machine-checked AND the statement independently anchored - a canonical tracker, or an audited correspondence to someone else's formal statement. Here the statement is your own, and the two estimates enter as theorem arguments, so what the kernel certifies is an implication rather than the theorem outright. That is a real and useful thing, and Lean-checked is exactly the rung for it.
+
+Status is now Candidate rather than Resolved: a full solution claimed and publicly checkable, with authoritative review pending. Disjunctivity of the binary expansion of the Erdos-Borwein constant is a strong claim in a hard area, and no specialist has read this yet.
+
+One request. The entry has no description of what the model actually did, and I would rather leave that blank than invent it. If you can say which parts ChatGPT-6 Astra produced - the construction, the Lean, the paper - send it and I will add it.
+
+The clean way to reach the top tier: formalize the two estimates, or get an analytic number theorist to read the argument.`,
+    edits: {
+      field: "Analytic number theory; digit distribution of constants",
+      verification: "lean-checked",
+      resolution: "candidate",
+      verificationNote:
+        "The Lean development proves disjunctivity of the binary expansion conditional on two hypotheses supplied as theorem arguments, not as axioms: AGP, the Alford-Granville-Pomerance estimate in the form of Vandehey's Proposition 2.1, and PrimeIntervalSupply, a standard prime number theorem consequence bounding the primes in (L, 2L) below by L/(3 log L). Both are published theorems rather than conjectures, so the mathematics is conditional only on known results; neither is formalized here. Read directly from lean/ErdosBorwein/PrimeInputs.lean on 8 September 2026. The audited endpoints depend on propext, Classical.choice and Quot.sound only. Because the statement is the author's own rather than anchored to a canonical tracker, and because what the kernel certifies is the implication, this takes the statement-unaudited tier. No specialist in analytic number theory has read the argument.",
+      significance: 25,
+      significanceNote:
+        "A question of Crandall's from 2002 about a named constant. Full disjunctivity of the binary expansion is substantially stronger than the single-block result the catalog already records, and digit-distribution results for specific constants are historically hard to come by.",
+    },
+    links: [
+      {
+        label: "PrimeInputs.lean: the two external estimates, stated exactly",
+        url: "https://github.com/CaptainSude/erdos-borwein-disjunctivity/blob/main/lean/ErdosBorwein/PrimeInputs.lean",
+        kind: "lean-statement",
+      },
+      {
+        label: "Lean verification record and axiom audit",
+        url: "https://github.com/CaptainSude/erdos-borwein-disjunctivity/blob/main/lean/VERIFICATION.md",
+        kind: "lean-proof",
+      },
+    ],
+  },
+
+  // ------------------------------------------------------------- 6. APPROVE
+  // The strongest submission in the batch. A named, prominent author, on
+  // arXiv, disclosing the model's role himself. Verified the disclosure
+  // verbatim from the arXiv comments field.
+  {
+    slug: "measures-on-partial-orders",
+    action: "approve",
+    reason: "other",
+    message: `Listed. This is the clearest submission in the current batch.
+
+I checked arXiv:2609.02021 and the comments field carries the disclosure verbatim: "ChatGPT was used to obtain many arguments. The writing was done entirely by the author." An author of Snowden's standing saying that in the paper itself, rather than leaving it to be inferred, is worth more to this catalog than any amount of third-party description.
+
+Unreviewed is correct and your note explains why precisely: the proofs are conventional and were checked by the author, who is also the person publishing, so this is author verification and not independent expert verification. Flake being thanked for discussions is not the same as an endorsement, and you were right not to read it as one.
+
+The entry has no year posed, which I have left empty rather than guessed at. If the poset case is identified as open in a specific Harman-Snowden paper, that would be worth adding.`,
+    edits: {
+      significance: 18,
+      significanceNote:
+        "Completely determines the measures on the Fraisse class of finite posets within the Harman-Snowden program, and is the first case where the space of measures is not equidimensional. A specialized but substantive research result, published by a leading author in the area.",
+    },
+  },
+
+  // ------------------- 7. APPROVE, fields unswapped and tier brought down
+  // The submitted verificationNote contained AI-role text and aiRole was
+  // empty, so the fields are put where they belong. On the tier: the Lean is
+  // real - FiniteMortalityBound.lean states exactly the claimed bound with no
+  // sorry and no axiom declarations - but no canonical anchor exists, so tier
+  // 1 does not hold. Partial rather than Candidate: it supplies the
+  // exponential alternative of Almeida-Steinberg Question 5.7 while the
+  // polynomial alternative stays open, which the submitter says plainly.
+  {
+    slug: "an-exponential-mortality-bound-for-finite-real-matrix-monoids",
+    action: "approve",
+    reason: "other",
+    message: `Listed, with the fields sorted out and the tier adjusted.
+
+First, a mechanical fix: the text you sent in the verification note was a description of what the model did, and the AI role field was empty. I have moved it to the AI role field and written an actual verification note in its place. Worth knowing for next time, since the two fields are read very differently.
+
+I checked the Lean rather than take the claim on trust. FiniteMortalityBound.lean states exists_short_zero_word_of_finite_real_monoid with the bound 2^(n-1) + (2^(n-1)-1)*n(n+1)/2 under exactly the hypotheses the write-up describes, with no sorry and no axiom declarations, and Audit.lean prints the axioms for each endpoint. The rational specialization is a real corollary via the cast. This is a faithful formalization of the theorem you claimed.
+
+One thing worth recording, since I went looking for a problem and did not find one: both your entries ship a 96-file SierpinskiFormal directory with identical filenames, which initially looked like one scaffold passed off twice. It is a shared library, and each entry has its own modules on top. The name is misleading given neither result concerns Sierpinski, and renaming it would save the next reviewer the same detour.
+
+Two changes:
+
+Verification is Lean-checked, statement unaudited rather than Lean-verified. Tier 1 needs the statement independently anchored - a canonical tracker, or audited correspondence to a formal statement someone else wrote. Here statement and proof were authored together. That is not a criticism of the formalization, which I read and which is sound; it is the difference between checking a proof and checking that the proof is of the right theorem.
+
+Status is Partial result rather than Candidate. You say yourself that this supplies the exponential alternative in Almeida-Steinberg Question 5.7 while the polynomial alternative remains open, so the question is advanced rather than settled.`,
+    edits: {
+      aiRole:
+        "All original mathematical contributions in the manuscript were produced by AI. The research developed a rank-descent argument for mortality under the finite-product-monoid promise: compressed return semigroups yield finite groups of invertible returns, finite-group averaging supplies an invariant symmetric form, and a symmetric-matrix lift converts rank descent into a short-word detection problem. Iterating the resulting rank-decreasing sandwich gives the final bound. The manuscript and the Lean formalization were also AI-produced, while established ingredients and prior results are separately credited. The human publisher selected and organized the research but does not claim subject-matter review.",
+      verification: "lean-checked",
+      resolution: "partial",
+      verificationNote:
+        "Checked here on 8 September 2026 from the published tree. mortality/lean/SierpinskiFormal/FiniteMortalityBound.lean states exists_short_zero_word_of_finite_real_monoid with the bound 2^(n-1) + (2^(n-1)-1)*n(n+1)/2, under exactly the hypotheses claimed: dimension positive, the range of the word map finite, and some word equal to zero. No sorry and no axiom declarations in that file; Audit.lean prints the axioms for each of the four endpoints. The rational statement is derived from the real one through the cast, so it is a corollary rather than a separate claim. The statement was authored alongside the proof rather than anchored to a canonical tracker, so this takes the statement-unaudited tier. No human mathematical review of the argument is claimed, and none has taken place.",
+      significance: 12,
+      significanceNote:
+        "Answers the exponential side of a 2009 question of Almeida and Steinberg and improves the Kiefer-Ryzhikov rational bound under the same finite-product promise. A clean quantitative advance in a specialized corner of matrix semigroup theory; the polynomial alternative, which is the interesting half, stays open.",
+    },
+    links: [
+      {
+        label: "FiniteMortalityBound.lean: the main theorem as formalized",
+        url: "https://github.com/egilburg/aimath/blob/main/mortality/lean/SierpinskiFormal/FiniteMortalityBound.lean",
+        kind: "lean-statement",
+      },
+      {
+        label: "Audit.lean: the printed endpoints and their axioms",
+        url: "https://github.com/egilburg/aimath/blob/main/mortality/lean/Audit.lean",
+        kind: "lean-proof",
+      },
+    ],
+  },
+
+  // ------------------------------- 8. APPROVE, with the tier brought down
+  // Best-documented Lean development of the batch, and the audit description
+  // is specific rather than promotional. Still tier 4: the statement is the
+  // same AI's, with no canonical anchor. Candidate rather than Resolved, on
+  // the same footing as the Kothe entry - full solution, publicly checkable,
+  // nobody qualified has read it.
+  {
+    slug: "sharp-finite-markov-order-in-intrinsic-sofic-dimension",
+    action: "approve",
+    reason: "other",
+    message: `Listed, with the tier and status adjusted one rung each.
+
+The verification note here is the most useful of the three Lean submissions in this batch: a pinned toolchain and Mathlib commit, the project-local import closure included, the endpoints audited to propext, Classical.choice and Quot.sound, reproduction instructions and source hashes. It also states its own limits - that Lean establishes the encoded statements and assumptions, not novelty or every prose claim, and that the two-sided extension is discussed rather than proved. Write-ups that bound their own claims are easier to trust, not harder.
+
+Two changes:
+
+Verification is Lean-checked, statement unaudited rather than Lean-verified. The top tier needs both halves: kernel-checked, and the statement independently anchored to a canonical tracker or an audited correspondence with a formal statement written by someone else. Here the same process produced statement and proof. Compare the Kothe entry in the catalog, which holds the top tier because its statement is byte-identical to the Formal Conjectures repository at a named commit - that external anchor is the whole difference, and it is available to you: if the Beal-Juge-Mairesse-Perrin horizon question gets a formal statement anywhere canonical, an audited correspondence would lift this straight up.
+
+Status is Candidate rather than Resolved, since you state that no professional mathematical review is claimed. Candidate means precisely this: a full solution, publicly checkable, authoritative review pending. It is the same status the Kothe disproof carries.
+
+The prior-art paragraph in your note is good practice - naming Beal-Senellart's N(N-1)/2 delay and Trahtman's construction as precedents for the quadratic phenomenon, and not claiming them. Keep doing that.
+
+Same note as on your mortality entry: the shared SierpinskiFormal library name has nothing to do with either result and cost me a detour to rule out a copied proof.`,
+    edits: {
+      verification: "lean-checked",
+      resolution: "candidate",
+      significance: 12,
+      significanceNote:
+        "Replaces the 2^(n^2-1) finite-Markov-order horizon of Beal, Juge, Mairesse and Perrin with the exact value n choose 2, and matches it with a construction. A sharp answer to a 2026 question in a specialized area, with the sharpness half doing most of the work.",
+    },
+    links: [
+      {
+        label: "Audit.lean: the printed endpoints and their axioms",
+        url: "https://github.com/egilburg/aimath/blob/main/sofic_markov_order/lean/Audit.lean",
+        kind: "lean-proof",
+      },
+    ],
+  },
+];
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const curator = await prisma.user.findFirst({
+    where: { pseudonym: "Rasmus Lindahl" },
+    select: { id: true, pseudonym: true },
+  });
+
+  let bad = 0;
+  for (const d of DECISIONS) {
+    const cur = await prisma.problem.findUnique({
+      where: { slug: d.slug },
+      select: { id: true, status: true, name: true },
+    });
+    if (!cur) throw new Error(`not found on ${db}: ${d.slug}`);
+    if (cur.status !== "pending")
+      throw new Error(`${d.slug} is ${cur.status}, not pending`);
+
+    console.log(
+      `${d.action === "reject" ? "DECLINE" : "APPROVE"}  ${cur.name.slice(0, 58)}  [${d.reason}]`,
+    );
+    console.log(
+      `  message : ${d.message.length}/${MESSAGE_MAX}${d.message.length > MESSAGE_MAX ? "  OVER" : ""}`,
+    );
+    if (d.message.length > MESSAGE_MAX) bad++;
+    for (const [k, v] of Object.entries(d.edits ?? {})) {
+      const lim = LIMITS.get(k);
+      if (typeof v === "string" && lim) {
+        const over = v.length > lim;
+        console.log(
+          `  ${k.padEnd(17)}: ${v.length}/${lim}${over ? `  OVER BY ${v.length - lim}` : ""}`,
+        );
+        if (over) bad++;
+      } else {
+        console.log(`  ${k.padEnd(17)}: ${JSON.stringify(v).slice(0, 70)}`);
+      }
+    }
+    for (const l of d.links ?? []) {
+      console.log(
+        `  link             : ${l.label.length}/${LINK_LABEL_MAX}  ${l.kind}`,
+      );
+      if (l.label.length > LINK_LABEL_MAX) bad++;
+    }
+  }
+  if (bad) throw new Error(`${bad} limit violation(s)`);
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+  if (!curator) throw new Error("curator not found on this database");
+
+  for (const d of DECISIONS) {
+    const cur = await prisma.problem.findUnique({
+      where: { slug: d.slug },
+      select: {
+        id: true,
+        submittedById: true,
+        _count: { select: { links: true } },
+      },
+    });
+    if (!cur) throw new Error(`vanished: ${d.slug}`);
+    const n = cur._count.links;
+
+    await prisma.$transaction([
+      prisma.problem.update({
+        where: { id: cur.id },
+        data: {
+          ...(d.edits ?? {}),
+          ...(d.links?.length
+            ? {
+                links: {
+                  create: d.links.map((l, i) => ({ ...l, position: n + i })),
+                },
+              }
+            : {}),
+          status: d.action === "approve" ? "published" : "rejected",
+          reviewedAt: new Date(),
+          reviewMessage: d.message,
+          reviewReason: d.reason,
+        } as never,
+      }),
+      prisma.directMessage.create({
+        data: {
+          userId: cur.submittedById!,
+          senderId: curator.id,
+          senderName: curator.pseudonym,
+          kind: "decision",
+          reason: d.reason,
+          body: d.message.slice(0, MESSAGE_MAX),
+          problemId: cur.id,
+        },
+      }),
+      prisma.problemActivity.create({
+        data: {
+          problemId: cur.id,
+          userId: curator.id,
+          userName: curator.pseudonym,
+          type: d.action === "approve" ? "approved" : "rejected",
+        },
+      }),
+    ]);
+    console.log(`applied: ${d.action} ${d.slug}`);
+  }
+
+  console.log(
+    "\nAPPLIED. Public caches lag until the next deploy; entry pages are right immediately.",
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/review-2026-09-09.ts
+++ b/scripts/review-2026-09-09.ts
@@ -1,0 +1,404 @@
+// Review of the eight submissions pending on 9 September 2026.
+// Five approved, three declined. The instruction was "approve all"; three
+// cannot be, and the reasons are recorded here rather than in a shrug.
+//
+// THE NAVIER-STOKES CLAIM. This is the Millennium Prize problem, so the
+// extraordinary-claims rule applies: expert review or formal verification
+// before listing, and not as a Candidate either. Formal verification holds,
+// and it is the best-anchored artifact this catalog has seen. Audited here on
+// 9 September at five levels:
+//
+//   1. The paper. 166 pages. Theorem 1.1 gives, for every nu > 0, a force
+//      f in C^inf_c(R^3 x (0,inf)) - compactly supported in space AND time,
+//      which trivially satisfies Fefferman's decay condition (5) - zero
+//      initial velocity, bounded kinetic energy, and limsup ||u(t)||_inf =
+//      infinity. Corollary 10.6 gives the torus case.
+//   2. The Lean artifact exists: github.com/openai/NavierStokesAndEuler.
+//      The paper itself never mentions Lean; the link is on the announcement
+//      page. Both submitters asserted the artifact, so it had to be found.
+//   3. THE STATEMENT ANCHOR, which is the whole ballgame. OpenAI's
+//      ComparatorChallenges/NavierStokes.lean says it "adapted" Formal
+//      Conjectures, and "adapted" can mean weakened. Diffed here against
+//      google-deepmind/formal-conjectures at the commit they name: the two
+//      compared theorems, navier_stokes_breakdown_R3 and
+//      navier_stokes_breakdown_periodic, are BYTE-IDENTICAL, as are every
+//      decay, energy and periodicity field they depend on. The only
+//      differences in the whole file are nine deleted lines: Formal
+//      Conjectures' alternatives (A) and (B), the existence-and-smoothness
+//      directions with f := 0, which OpenAI does not claim. Nothing was
+//      weakened, and the anchor is a third party's formalisation.
+//   4. Counts, taken independently across the repository: 2,486 Lean files,
+//      616,276 lines, zero sorry outside the deliberate challenge
+//      placeholders, zero axiom declarations, zero native_decide, zero
+//      unsafe. comparator.json permits only propext, Quot.sound,
+//      Classical.choice and enables the independent nanoda kernel.
+//   5. The solution module states both theorems verbatim and discharges them
+//      through ComparatorBridge, printing axioms for each.
+//
+//   Not done: the build. Candidate rather than Resolved because no
+//   mathematician has read it, it was released on 8 September, and Clay's own
+//   process wants a refereed publication plus two years of acceptance.
+//
+// TWO PAIRS OF DUPLICATES. Both Navier-Stokes submissions are the same OpenAI
+// result from two anonymous accounts; the earlier one is kept because its
+// title says "with smooth forcing" on its face, which is the nuance that stops
+// this entry being misread, and because first-come is the fair rule. Protti
+// sent two C11 submissions and asked in the second to have R5/R6 folded into
+// the first rather than duplicated - so that is what happens.
+//
+// ONE REAL REJECTION. "Induced Regular Subgraphs" is Erdos problem 182, which
+// erdosproblems.com marks PROVED - resolved by Janzer and Sudakov in 2023, by
+// humans, three years before this claim. That is solved-elsewhere-first, and
+// publishing it would have been the kind of error that costs a catalog its
+// credibility.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { PrismaClient } from "@prisma/client";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { MESSAGE_MAX } from "../src/lib/messages";
+
+const prisma = new PrismaClient();
+const APPLY = process.argv.includes("--apply");
+const LINK_LABEL_MAX = 120;
+
+const LIMITS = new Map<string, number>();
+for (const s of [...EDITABLE_FIELDS, ...CURATOR_FIELDS])
+  if (s.maxLength) LIMITS.set(s.key, s.maxLength);
+
+const OAI = "https://github.com/openai/NavierStokesAndEuler/blob/main";
+const FC_PIN = "8bf45ed70d48b2b2a501de9c00b26bfa38c573ee";
+
+type LinkIn = { label: string; url: string; kind: string };
+type Decision = {
+  slug: string;
+  action: "approve" | "reject";
+  reason: string;
+  message: string;
+  edits?: Record<string, unknown>;
+  links?: LinkIn[];
+};
+
+const DECISIONS: Decision[] = [
+  // ----------------------------------------------- 1. Navier-Stokes, APPROVE
+  {
+    slug: "navier-stokes-millennium-prize-problem-finite-time-breakdown-with-smooth-forcing",
+    action: "approve",
+    reason: "other",
+    message: `Listed, at the top of the catalog. Thank you for sending it, and for a submission that got the hard parts right: naming the C/D route in the title, stating plainly that this does not settle unforced Navier-Stokes, and picking Candidate.
+
+I raised your verification tier from Lean-checked to Lean-verified, because the audit your note said was missing is one I could do. You wrote that nobody had checked whether the formal statement matches Fefferman's C/D. Here is that check.
+
+OpenAI's ComparatorChallenges/NavierStokes.lean says it "adapted" Formal Conjectures' formalisation, and "adapted" can hide a weakening, so I diffed it against google-deepmind/formal-conjectures at the commit they name. The two compared theorems are byte-identical to DeepMind's, as is every decay, energy and periodicity condition they rest on. The only differences in the entire file are nine deleted lines: Formal Conjectures' alternatives (A) and (B), the existence-and-smoothness directions with zero force, which OpenAI does not claim. So the statement is anchored to a third party's formalisation, not to one the prover wrote for itself. That is what the top tier asks for.
+
+The rest: 2,486 Lean files, 616,276 lines, no sorry outside the deliberate challenge placeholders, no axiom declarations, no native_decide, no unsafe. comparator.json permits only the three standard axioms and enables the independent nanoda kernel. In the paper, Theorem 1.1's force is compactly supported in space and time, which satisfies Fefferman's condition (5) outright rather than approximately.
+
+Status stays Candidate, as you asked. No mathematician has read it, it is a day old, and Clay's own rules want a refereed publication and two years of general acceptance. Significance 78 was the previous ceiling here; this is 87.
+
+One correction to your note: the paper never mentions Lean. The formalisation link is on the announcement page only, which is worth knowing if you cite the PDF alone.`,
+    edits: {
+      verification: "lean-verified",
+      resolution: "candidate",
+      significance: 87,
+      verificationNote:
+        "Audited here on 9 September 2026. Statement anchor: OpenAI's ComparatorChallenges/NavierStokes.lean was diffed against google-deepmind/formal-conjectures at commit 8bf45ed, the commit its header names. The two compared theorems, navier_stokes_breakdown_R3 and navier_stokes_breakdown_periodic, are byte-identical to DeepMind's, as are the decay, periodicity and energy conditions they depend on; the only differences in the file are nine deleted lines carrying Formal Conjectures' alternatives (A) and (B), which OpenAI does not claim. The statement is therefore anchored to an independent third party's formalisation of Fefferman's conditions, not to one written by the prover. Counts taken independently: 2,486 Lean files, 616,276 lines, zero sorry outside the deliberate challenge placeholders, zero axiom declarations, zero native_decide, zero unsafe. comparator.json permits only propext, Quot.sound and Classical.choice and enables the independent nanoda kernel; the solution module states both theorems verbatim and discharges them via ComparatorBridge. In the paper, Theorem 1.1's force lies in C^inf_c(R^3 x (0,inf)), compactly supported in space and time, satisfying Fefferman's decay condition (5) outright. Not rebuilt here. No mathematician has read the argument: released 8 September 2026, no referee, and Clay's own process requires publication in a refereed journal plus two years of general acceptance.",
+      significanceNote:
+        'A Millennium Prize problem, resolved through alternatives (C) and (D) of Fefferman\'s official statement, which permit a smooth force with rapid decay. Below the 100 reserved for the Riemann hypothesis and above the Collatz band, but not at the ceiling: the forced alternatives are the more tractable half of the Clay problem, and what most readers mean by "Navier-Stokes" - global regularity for the unforced equations - is untouched. Held at Candidate because no human has read it.',
+    },
+    links: [
+      {
+        label: "OpenAI's comparator challenge statement for (C) and (D)",
+        url: `${OAI}/ComparatorChallenges/NavierStokes.lean`,
+        kind: "lean-statement",
+      },
+      {
+        label:
+          "Formal Conjectures' original, which the statement matches byte for byte",
+        url: `https://github.com/google-deepmind/formal-conjectures/blob/${FC_PIN}/FormalConjectures/Millenium/NavierStokes.lean`,
+        kind: "problem-record",
+      },
+      {
+        label: "The Lean development and comparator configuration",
+        url: "https://github.com/openai/NavierStokesAndEuler",
+        kind: "lean-proof",
+      },
+      {
+        label: "Fefferman's official Clay problem description",
+        url: "https://www.claymath.org/wp-content/uploads/2022/06/navierstokes.pdf",
+        kind: "problem-record",
+      },
+    ],
+  },
+
+  // -------------------------------------- 4. Navier-Stokes duplicate, DECLINE
+  {
+    slug: "navier-stokes-existence-and-smoothness-problem",
+    action: "reject",
+    reason: "duplicate",
+    message: `Closing this as a duplicate, and I want to be clear that it is the better-researched of the two: you were the one who found that the comparator statements come from Formal Conjectures rather than from OpenAI's own hand, and you reasoned correctly about what that does to the verification tier.
+
+Two submissions arrived for the same OpenAI result seven hours apart. I kept the earlier one, on the ordinary first-come rule and because its title carries "finite-time breakdown with smooth forcing" on its face. That phrase is the nuance that stops this entry being read as "AI solved Navier-Stokes, full stop", and a reader who only sees a headline should still meet it.
+
+Your work is in the listed entry rather than discarded. Your Formal Conjectures observation is what sent me to diff OpenAI's challenge file against DeepMind's original, and it holds up better than you claimed: the two compared theorems are byte-identical, not merely adapted. That is why the entry now carries Lean-verified instead of the Lean-checked the other submission asked for. Your Leray 1934 dating is also the honest one and I have kept the older provenance in mind.
+
+Nothing here reflects on the submission. Please keep sending them.`,
+  },
+
+  // ------------------------------------------------- 3. Fermat constant
+  {
+    slug: "reciprocal-fermat-constant-is-nonnormal",
+    action: "approve",
+    reason: "other",
+    message: `Listed, with the tier down one rung from what you asked.
+
+First, credit where it is due: this is a visible improvement on your Erdos-Borwein submission from yesterday. That one proved its theorem conditional on two published results it left unformalised, which is why it sits at Lean-checked. This one closes that gap - fermat_theorem in Full.lean is unconditional, and it gets there by supplying normalDistanceTest, reciprocalFermat_replicationMeans and reciprocalFermat_periodicMeans as proved terms rather than as hypotheses. I checked NormalTest.lean: normalDistanceTest really is proved, not assumed. Zero sorry across 32 files and 3,909 lines.
+
+Verification is Lean-checked, statement unaudited, rather than Lean-verified. The top tier needs the statement anchored outside the development - a canonical tracker, or an audited correspondence with a formal statement someone else wrote. Your package has no Challenge/Solution split and no comparator configuration, so the statement of what "nonnormal" means is your own. That is not a doubt about the proof, which I read; it is the difference between checking a proof and checking that the proof is of the right theorem. The Navier-Stokes entry listed today is the contrast: its statement is byte-identical to a DeepMind formalisation, and that external anchor is the whole difference.
+
+One practical request. Shipping the Lean as fermat-lean-complete.zip inside an otherwise empty repository means nobody can browse it, diff it, or run CI on it, and I had to download and unpack it to review it. Committing the sources would cost you nothing and make the next reviewer's job, and any future reader's, far easier.`,
+    edits: {
+      verification: "lean-checked",
+      significance: 18,
+      significanceNote:
+        "Nonnormality of a specific named constant in base 2, with the digit-frequency machinery proved rather than assumed. A rung below the site's Erdos-Borwein disjunctivity entry: the same flavour of result, on a constant with a shorter history and less of a literature behind the question.",
+    },
+  },
+
+  // --------------------------------------------------- 2. Shannon C11, APPROVE
+  {
+    slug: "an-improved-lower-bound-for-the-shannon-capacity-of-c-11",
+    action: "approve",
+    reason: "other",
+    message: `Listed, with the R5 and R6 material attached as you asked in your second submission.
+
+You did the right thing twice over: you flagged the existing odd-cycles entry rather than letting me find a near-duplicate, and when you had a stronger bound you asked for it to be folded into the pending entry instead of opening a second one. That second submission is closed as a duplicate pointing here, and its R5/R6 links now hang off this entry.
+
+One thing I have deliberately not done: rewrite the headline number. Your R6 payload claims a stronger bound than the R3 figure this submission carries, and I am not going to transcribe a value out of a release archive and present it as the entry's result. Send an edit request with the final bound stated plainly and I will apply it, or say the word and I will read the R6 certificate and set it myself.
+
+A question worth your view, since you know this quantity better than most. The catalog now has Frontiers, which track a moving bound as a staircase of steps rather than as one entry per improvement. The Shannon capacity of C11 looks exactly like that shape: a tracked quantity with a sequence of records, BPZ then you, R3 then R5 then R6. If the improvements keep coming, a frontier serves readers better than an entry per increment, and your successive certificates would each be a step on it. Would you rather it lived that way?
+
+Significance 14. For calibration, the odd-cycles records entry sits at 35, and this is one further improvement on one cycle length.`,
+    edits: {
+      significance: 14,
+      significanceNote:
+        "A further improvement to the best known lower bound for the Shannon capacity of one odd cycle, on a quantity the catalog already tracks. Real and certified, but narrower than the odd-cycles records entry it improves on, which covers the family.",
+    },
+    links: [
+      {
+        label: "R6 v0.3.0: checked release archive and checksum",
+        url: "https://github.com/matthewprotti/c11-shannon-capacity-lower-bound/releases/tag/v0.3.0",
+        kind: "code",
+      },
+      {
+        label: "R5 v0.2.0: checked release archive and checksum",
+        url: "https://github.com/matthewprotti/c11-shannon-capacity-lower-bound/releases/tag/v0.2.0",
+        kind: "code",
+      },
+    ],
+  },
+
+  // ------------------------------------------ 5. Shannon C11 duplicate, DECLINE
+  {
+    slug: "stronger-lower-bounds-for-the-shannon-capacity-of-c-11",
+    action: "reject",
+    reason: "duplicate",
+    message: `Closed as a duplicate, which is exactly what you asked for: your note said to incorporate R5 and R6 into the earlier pending entry rather than create duplicates for the sequence. Done - that entry is now published and carries your R5 and R6 release links.
+
+Asking a reviewer to merge rather than stack is unusual and it makes the catalog better, so thank you. The one thing I did not carry over is the headline number: I will not transcribe a bound out of a release archive and publish it as the result. Send the final figure in an edit request, or tell me to read the R6 certificate and set it myself, and it goes in.
+
+I have also asked on the listed entry whether this quantity would be better tracked as a Frontier, given the R3/R5/R6 sequence and the earlier BPZ baseline. Your answer would carry weight.`,
+  },
+
+  // --------------------------------------------------- 6. Erdos 1221, APPROVE
+  {
+    slug: "erdos-problem-1221",
+    action: "approve",
+    reason: "other",
+    message: `Listed, but as a Candidate rather than Resolved.
+
+I checked erdosproblems.com for #1221 and the problem is still marked OPEN. There is one proof claim on the page - presumably this one - and the site prints its own warning next to it: appearing there "is no guarantee of proof correctness, and does not mean that anyone associated with this site has examined any part of the proof." Proof expositions: zero.
+
+That matters here because acceptance by erdosproblems.com is the bar this catalog uses to move an Erdos claim from Candidate to Resolved. Several entries have made that move, and each waited for the page to change. Yours has not changed yet, so the honest status is Candidate: a solution claimed, publicly checkable, authoritative review pending. It flips the day Bloom marks the problem solved or an exposition appears, and you are welcome to prompt me then.
+
+If a Lean formalisation exists or becomes possible, that is the other route up, and for a question like this one - de Bruijn and Erdos's asymptotics for circle distributions - it looks like the kind of statement that could be formalised.`,
+    edits: {
+      resolution: "candidate",
+      significance: 10,
+      significanceNote:
+        "A numbered Erdos problem from de Bruijn and Erdos, 1949, sitting at the reference point for the scale. Still marked open by erdosproblems.com with the claim unexamined, which is what holds it at Candidate rather than what sets the score.",
+    },
+    links: [
+      {
+        label: "erdosproblems.com/1221: the problem record, still marked open",
+        url: "https://www.erdosproblems.com/1221",
+        kind: "problem-record",
+      },
+    ],
+  },
+
+  // ------------------------------- 7. Induced regular subgraphs, DECLINE
+  {
+    slug: "induced-regular-subgraphs",
+    action: "reject",
+    reason: "solved-elsewhere-first",
+    message: `Declining this one, and the reason is about the problem's history rather than about your submission.
+
+This is Erdos problem 182, and erdosproblems.com marks it PROVED: "This has been solved in the affirmative." It was resolved by Janzer and Sudakov in 2023, who showed that some C(k) exists with any graph on n vertices having at least Cn log log n edges containing a k-regular subgraph. Chakraborti, Janzer, Methuku and Montgomery then sharpened the constant to C(k) much less than k^2 in 2024, which is optimal up to an absolute constant, and a construction of Pyber, Rodl and Szemeredi shows that is best possible.
+
+So the question was answered by humans three years before this claim, and the catalog records problems first solved with an AI in the loop. A later proof cannot be shown to be independent of a published one, and reproving a settled theorem is explicitly out of scope. That holds however good the new argument is.
+
+Worth saying: the same account's other submission today, on Erdos #1221, is listed. That problem is genuinely still open, and the difference between the two is entirely whether the problem was waiting. Checking the status line on erdosproblems.com before submitting will save you the round trip - it is the first thing I check.`,
+  },
+
+  // ----------------------------------------------- 8. Koizumi-Liu, APPROVE
+  {
+    slug: "koizumi-liu-eventual-sign-alternation-conjecture",
+    action: "approve",
+    reason: "other",
+    message: `Listed as submitted. A clean one, and the tiers you chose are the ones I would have chosen.
+
+I verified the disclosure rather than taking it from your note, and it is unusually explicit. The paper carries a section headed "Human-AI collaboration": "This work was developed through extensive interaction between the author and OpenAI's GPT-5.6 Sol and GPT-6 Astra. AI assistance included developing mathematical arguments, performing computations, and drafting and revising the manuscript. The author critically evaluated the AI-generated material, independently verified the mathematical arguments and references, and takes full responsibility for the paper." A named author putting that in the paper itself, rather than leaving it to be inferred, is worth more to this catalog than any third-party description of the same facts.
+
+AI-co-developed is right on that wording: the models developed arguments, and Koizumi verified them and stands behind the result. Unreviewed is right too - it is a preprint, and the verification is the author's own, which is a different thing from an independent check even when the author is the person who posed the conjecture.
+
+Your note about the counterexample being one part of a broader structural paper is a useful framing and I have kept the entry scoped to the conjecture it refutes.`,
+    edits: {
+      significance: 12,
+      significanceNote:
+        "Refutes a named conjecture of Koizumi and Liu with an explicit rank-six counterexample, inside a broader paper on matroid magnitude and motivic zeta functions. Specialised, recent, and settled cleanly in the negative by one of the people who posed it.",
+    },
+  },
+];
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const curator = await prisma.user.findFirst({
+    where: { pseudonym: "Rasmus Lindahl" },
+    select: { id: true, pseudonym: true },
+  });
+
+  let bad = 0;
+  for (const d of DECISIONS) {
+    const cur = await prisma.problem.findUnique({
+      where: { slug: d.slug },
+      select: { id: true, status: true, name: true },
+    });
+    if (!cur) throw new Error(`not found on ${db}: ${d.slug}`);
+    if (cur.status !== "pending")
+      throw new Error(`${d.slug} is ${cur.status}, not pending`);
+
+    console.log(
+      `${d.action === "reject" ? "DECLINE" : "APPROVE"}  ${cur.name.slice(0, 56)}  [${d.reason}]`,
+    );
+    console.log(
+      `  message : ${d.message.length}/${MESSAGE_MAX}${d.message.length > MESSAGE_MAX ? "  OVER" : ""}`,
+    );
+    if (d.message.length > MESSAGE_MAX) bad++;
+    for (const [k, v] of Object.entries(d.edits ?? {})) {
+      const lim = LIMITS.get(k);
+      if (typeof v === "string" && lim) {
+        const over = v.length > lim;
+        console.log(
+          `  ${k.padEnd(17)}: ${v.length}/${lim}${over ? `  OVER BY ${v.length - lim}` : ""}`,
+        );
+        if (over) bad++;
+      } else {
+        console.log(`  ${k.padEnd(17)}: ${JSON.stringify(v).slice(0, 60)}`);
+      }
+    }
+    for (const l of d.links ?? []) {
+      console.log(
+        `  link             : ${l.label.length}/${LINK_LABEL_MAX}  ${l.kind}`,
+      );
+      if (l.label.length > LINK_LABEL_MAX) bad++;
+    }
+  }
+  if (bad) throw new Error(`${bad} limit violation(s)`);
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+  if (!curator) throw new Error("curator not found on this database");
+
+  for (const d of DECISIONS) {
+    const cur = await prisma.problem.findUnique({
+      where: { slug: d.slug },
+      select: {
+        id: true,
+        submittedById: true,
+        _count: { select: { links: true } },
+      },
+    });
+    if (!cur) throw new Error(`vanished: ${d.slug}`);
+    const n = cur._count.links;
+
+    await prisma.$transaction([
+      prisma.problem.update({
+        where: { id: cur.id },
+        data: {
+          ...(d.edits ?? {}),
+          ...(d.links?.length
+            ? {
+                links: {
+                  create: d.links.map((l, i) => ({ ...l, position: n + i })),
+                },
+              }
+            : {}),
+          status: d.action === "approve" ? "published" : "rejected",
+          reviewedAt: new Date(),
+          reviewMessage: d.message,
+          reviewReason: d.reason,
+        } as never,
+      }),
+      prisma.directMessage.create({
+        data: {
+          userId: cur.submittedById!,
+          senderId: curator.id,
+          senderName: curator.pseudonym,
+          kind: "decision",
+          reason: d.reason,
+          body: d.message.slice(0, MESSAGE_MAX),
+          problemId: cur.id,
+        },
+      }),
+      prisma.problemActivity.create({
+        data: {
+          problemId: cur.id,
+          userId: curator.id,
+          userName: curator.pseudonym,
+          type: d.action === "approve" ? "approved" : "rejected",
+        },
+      }),
+    ]);
+    console.log(`applied: ${d.action} ${d.slug}`);
+  }
+
+  console.log(
+    "\nAPPLIED. Public caches lag until the next deploy; new entry pages are right immediately, edits to already-cached pages take up to an hour.",
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -11,6 +11,7 @@ import { MethodGrowthChart } from "@/components/MethodGrowthChart";
 import { Icon, type IconName } from "@/components/Icons";
 import { ModelsChart } from "@/components/ModelsChart";
 import { OpenSourceChart } from "@/components/OpenSourceChart";
+import { PeakChart } from "@/components/PeakChart";
 import { ReferencesChart } from "@/components/ReferencesChart";
 import { SolveRatioChart } from "@/components/SolveRatioChart";
 import { InfoTip } from "@/components/Tooltip";
@@ -202,6 +203,13 @@ export default async function StatsPage() {
             candidate (hollow) and excludes partial/variant/retracted. */}
         <ChartCard id="significance-vs-age" label="significance vs. age">
           <ReferencesChart problems={slim} />
+        </ChartCard>
+        {/* Sits beside the scatter deliberately: both are about weight
+            rather than volume, and this one is the scatter's story rolled
+            forward in time. `slim`, not `resolved`, because a candidate
+            claim under review is still the month's biggest event. */}
+        <ChartCard id="peak-per-month" label="most significant per month">
+          <PeakChart problems={slim} today={today} />
         </ChartCard>
         <ChartCard id="by-vendor" label="solves per vendor">
           <ModelsChart problems={resolved} today={today} />

--- a/src/components/PeakChart.tsx
+++ b/src/components/PeakChart.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { ChartProblem } from "@/lib/problems";
+import { deTeX } from "@/components/TeX";
+import { TimeAxis } from "@/components/TimeControls";
+import {
+  monthlyPeaks,
+  recordMonths,
+  runningPeak,
+  type MonthPeak,
+} from "@/lib/monthly-peak";
+import { labelWidth, placeLabels } from "@/lib/scatter-labels";
+
+// The heaviest problem resolved in each month, from the first solve to today.
+//
+// Every other time chart here counts things, so every other time chart goes up
+// as the catalog grows. This one cannot: a month is worth its best result, so
+// the line only moves when something genuinely bigger lands. It is the one
+// view on the page that shows the ceiling rising rather than the pile
+// deepening.
+//
+// No time-range toggle, unlike its siblings. "From the first entry to today"
+// is the whole point - a windowed version would hide the early flat stretch
+// that gives the recent jumps their meaning.
+
+const VIEW_W = 640;
+const VIEW_H = 360;
+const MARGIN = { top: 30, right: 20, bottom: 40, left: 44 };
+const PLOT_W = VIEW_W - MARGIN.left - MARGIN.right;
+const PLOT_H = VIEW_H - MARGIN.top - MARGIN.bottom;
+
+function niceMax(v: number, step: number) {
+  return Math.max(step, Math.ceil(v / step) * step);
+}
+
+export function PeakChart({
+  problems,
+  today,
+}: {
+  problems: ChartProblem[];
+  today: string;
+}) {
+  const [hover, setHover] = useState<number | null>(null);
+  const router = useRouter();
+
+  const rows: MonthPeak[] = monthlyPeaks(problems, today);
+  if (rows.length === 0) return null;
+
+  const records = recordMonths(rows);
+  const running = runningPeak(rows);
+  const yMax = niceMax(Math.max(10, ...rows.map((r) => r.significance)), 10);
+
+  const months = rows.map((r) => r.month);
+  const x = (i: number) =>
+    MARGIN.left +
+    (rows.length === 1 ? PLOT_W / 2 : (i / (rows.length - 1)) * PLOT_W);
+  const y = (v: number) => MARGIN.top + PLOT_H - (v / yMax) * PLOT_H;
+
+  // Bars thin enough that a long timeline does not turn into a solid block,
+  // and never wider than the gap between months.
+  const barW = Math.max(
+    2,
+    Math.min(14, (PLOT_W / Math.max(1, rows.length)) * 0.6),
+  );
+
+  // Only record-setting months are labelled: on a running-maximum chart every
+  // other month is by definition below a line the reader can already see.
+  // Reuses the scatter's packer, so a run of records in consecutive months
+  // cannot overprint - which is exactly what August and September 2026 are.
+  const placed = placeLabels(
+    rows
+      .map((r, i) => ({ r, i }))
+      .filter(({ r }) => records.has(r.month) && r.top)
+      .reverse()
+      .map(({ r, i }) => ({
+        key: r.month,
+        cx: x(i),
+        cy: y(r.significance),
+        width: labelWidth(deTeX(r.top!.shortName)),
+        anchor:
+          x(i) > VIEW_W - 110
+            ? ("end" as const)
+            : x(i) < MARGIN.left + 110
+              ? ("start" as const)
+              : ("middle" as const),
+      })),
+    {
+      minY: MARGIN.top,
+      maxY: MARGIN.top + PLOT_H,
+      minX: MARGIN.left,
+      maxX: VIEW_W - MARGIN.right,
+    },
+  );
+
+  const ticks: number[] = [];
+  for (let v = 0; v <= yMax; v += yMax / 3) ticks.push(Math.round(v));
+
+  const active = hover !== null ? rows[hover] : null;
+  // The record line as a step: it holds its level through empty months rather
+  // than sloping between results, because nothing happened in between.
+  const stepPath = running
+    .map((v, i) => {
+      const px = x(i);
+      const py = y(v);
+      return i === 0
+        ? `M ${px} ${py}`
+        : `L ${px} ${y(running[i - 1])} L ${px} ${py}`;
+    })
+    .join(" ");
+
+  return (
+    <div>
+      <h2 className="font-serif text-lg text-[var(--ink)]">
+        Most significant result per month
+      </h2>
+      <p className="mt-1 text-xs text-[var(--ink-muted)]">
+        The heaviest problem resolved in each month since the record begins.
+        Unlike the other charts here this one does not rise with volume: it
+        moves only when something bigger lands. The line is the running best.
+      </p>
+
+      <svg
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        className="mt-3 w-full overflow-visible"
+        role="img"
+        aria-label="Bar chart of the highest significance resolved in each month, with a running-best line that steps up when a new record lands."
+      >
+        {ticks.map((t) => (
+          <g key={t}>
+            <line
+              x1={MARGIN.left}
+              x2={VIEW_W - MARGIN.right}
+              y1={y(t)}
+              y2={y(t)}
+              stroke="var(--rule)"
+              strokeWidth={1}
+            />
+            <text
+              x={MARGIN.left - 8}
+              y={y(t) + 4}
+              textAnchor="end"
+              style={{ fontSize: 11, fill: "var(--ink-muted)" }}
+            >
+              {t}
+            </text>
+          </g>
+        ))}
+
+        {/* 18px below the baseline, the same offset every sibling chart uses.
+            Passing the baseline itself drew the month labels through the
+            bottoms of the bars. */}
+        <TimeAxis
+          range={months}
+          gran="month"
+          x={x}
+          y={VIEW_H - MARGIN.bottom + 18}
+        />
+
+        {/* The running best, drawn under the bars so a record month's bar
+            sits on top of the step it created. */}
+        <path
+          d={stepPath}
+          fill="none"
+          stroke="var(--accent-orange)"
+          strokeWidth={1.5}
+          strokeOpacity={0.65}
+        />
+
+        {rows.map((r, i) => {
+          if (!r.top) return null;
+          const isRecord = records.has(r.month);
+          const h = MARGIN.top + PLOT_H - y(r.significance);
+          return (
+            <rect
+              key={r.month}
+              x={x(i) - barW / 2}
+              y={y(r.significance)}
+              width={barW}
+              height={Math.max(1, h)}
+              rx={1}
+              fill="var(--accent-blue)"
+              fillOpacity={hover === i ? 1 : isRecord ? 0.95 : 0.5}
+            />
+          );
+        })}
+
+        {/* Hit strips: one per month, full height, so hovering anywhere in a
+            column works rather than only on a two-pixel bar. */}
+        {rows.map((r, i) => (
+          <rect
+            key={`hit-${r.month}`}
+            x={x(i) - PLOT_W / Math.max(1, rows.length) / 2}
+            y={MARGIN.top}
+            width={Math.max(4, PLOT_W / Math.max(1, rows.length))}
+            height={PLOT_H}
+            fill="transparent"
+            style={{ cursor: r.top ? "pointer" : "default" }}
+            onMouseEnter={() => setHover(i)}
+            onMouseLeave={() => setHover(null)}
+            onClick={() => r.top && router.push(`/problem/${r.top.slug}`)}
+          />
+        ))}
+
+        {rows.map((r, i) => {
+          const label = placed.get(r.month);
+          if (!label || !r.top) return null;
+          return (
+            <text
+              key={`lab-${r.month}`}
+              x={label.x}
+              y={label.y}
+              textAnchor={label.anchor}
+              style={{ fontSize: 11, fill: "var(--ink)" }}
+            >
+              {deTeX(r.top.shortName)}
+            </text>
+          );
+        })}
+      </svg>
+
+      <p className="mt-2 min-h-[2.5rem] text-xs text-[var(--ink-secondary)]">
+        {active?.top ? (
+          <>
+            <span className="text-[var(--ink)]">
+              {deTeX(active.top.shortName)}
+            </span>{" "}
+            &middot; {active.significance}/100 &middot; {active.month}
+          </>
+        ) : (
+          <>
+            {records.size} months set a new record. Hover a month for its
+            result, click to open it.
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/src/components/ReferencesChart.tsx
+++ b/src/components/ReferencesChart.tsx
@@ -6,6 +6,7 @@ import { ageAtSolve, type ChartProblem } from "@/lib/problems";
 import { useChartSettings } from "@/lib/chart-settings";
 import { TierToggle } from "@/components/TimeControls";
 import { TeX, deTeX } from "@/components/TeX";
+import { labelWidth, placeLabels } from "@/lib/scatter-labels";
 
 // This chart plots SIGNIFICANCE (the AI-estimated problem weight) against how
 // long the problem stood open. The dense band at 10 is the point: almost every
@@ -39,6 +40,16 @@ const MARGIN = { top: 34, right: 24, bottom: 44, left: 56 };
 const PLOT_W = VIEW_W - MARGIN.left - MARGIN.right;
 const PLOT_H = VIEW_H - MARGIN.top - MARGIN.bottom;
 
+/// Labels near either edge anchor inward so they stay inside the viewBox -
+/// the svg has overflow visible, and a centred label on an edge point would
+/// poke out of the card (and on phones, widen the page). Shared with the
+/// label packer, which has to measure the box the renderer actually draws.
+function labelAnchorAt(cx: number): "start" | "middle" | "end" {
+  if (cx > VIEW_W - 100) return "end";
+  if (cx < MARGIN.left + 100) return "start";
+  return "middle";
+}
+
 function niceMax(value: number, step: number) {
   return Math.max(step, Math.ceil(value / step) * step);
 }
@@ -55,7 +66,12 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
   // Legend chips toggle point groups (proved / disproved / under review),
   // persisted across reloads. Axes stay fixed so toggling declutters without
   // reflowing the plot.
-  const { tier, setTier, hidden, toggleSeries: toggleGroup } = useChartSettings("scatter");
+  const {
+    tier,
+    setTier,
+    hidden,
+    toggleSeries: toggleGroup,
+  } = useChartSettings("scatter");
 
   // Resolved entries plot as filled dots; CANDIDATE entries (a full solution
   // claimed and vetted, community review pending) plot as hollow rings so a
@@ -73,8 +89,12 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
   const plottable = enriched.filter(
     (
       d,
-    ): d is { problem: ChartProblem; age: number; significance: number; claimed: boolean } =>
-      d.age !== null && d.significance !== null,
+    ): d is {
+      problem: ChartProblem;
+      age: number;
+      significance: number;
+      claimed: boolean;
+    } => d.age !== null && d.significance !== null,
   );
   const pending = enriched.length - plottable.length;
   // Dropped before `enriched` even exists: partials and variants improve a
@@ -86,7 +106,10 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
 
   const xMax = niceMax(Math.max(1, ...plottable.map((d) => d.age)), 20);
   const yStep = 10;
-  const yMax = niceMax(Math.max(1, ...plottable.map((d) => d.significance)), yStep);
+  const yMax = niceMax(
+    Math.max(1, ...plottable.map((d) => d.significance)),
+    yStep,
+  );
 
   const xTicks = ticks(xMax, 20);
   const yTicks = ticks(yMax, yStep);
@@ -95,9 +118,9 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
   const y = (sig: number) => MARGIN.top + PLOT_H - (sig / yMax) * PLOT_H;
 
   // Legend reflects only series actually drawn as points.
-  const seriesPresent = Array.from(new Set(plottable.map((d) => d.problem.solveType))).filter(
-    (t) => t in SOLVE_TYPE_COLOR,
-  );
+  const seriesPresent = Array.from(
+    new Set(plottable.map((d) => d.problem.solveType)),
+  ).filter((t) => t in SOLVE_TYPE_COLOR);
 
   // The tier filter hides POINTS but never touches the axes above, which are
   // still scaled from the full plottable set. Deliberate, and the same reason
@@ -115,37 +138,42 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
   // Draw the dense low band first so the labeled strikes sit on top of it.
   const drawOrder = [...shown].sort((a, b) => a.significance - b.significance);
 
-  // Label de-collision: several labeled points share a score band (four sit
-  // at 35), so neighbouring labels would overprint. Greedy level stacking:
-  // walk labeled points left to right and lift a label one 14px row for each
-  // already-placed label it would collide with (close in x AND in y).
-  const labelYBySlug = new Map<string, number>();
-  {
-    const placed: { cx: number; w: number; labelY: number }[] = [];
-    const labeled = plottable
+  // Label de-collision. See src/lib/scatter-labels.ts for the packing and why
+  // it drops rather than overprints. Three things matter at this call site:
+  //
+  // Placement runs over `shown`, not `plottable`, so the legend and tier
+  // filters actually declutter the plot. Laying out hidden points reserved
+  // space nothing occupied and pushed visible labels off their own dots.
+  //
+  // Order is by significance, highest first, so when the crowded middle band
+  // runs out of room the name that survives is the one a reader came for.
+  //
+  // The anchor has to match what the renderer draws below, or the collision
+  // test measures a box the label does not occupy.
+  const labelYBySlug = placeLabels(
+    shown
       .filter((d) => d.significance >= LABEL_THRESHOLD)
-      .sort((a, b) => x(a.age) - x(b.age));
-    for (const d of labeled) {
-      const cx = x(d.age);
-      // Estimated rendered width at fontSize 14 - the collision test must use
-      // the actual text lengths, or long neighbours still overprint. Measured
-      // on the deTeX'd form, which is what the label actually draws: a
-      // math-bearing short name is shorter rendered than its $...$ source.
-      const w = deTeX(d.problem.shortName).length * 6.4 + 8;
-      let labelY = y(d.significance) - 12;
-      // Lift one line at a time until no placed label overlaps horizontally
-      // at this height.
-      for (let guard = 0; guard < 6; guard++) {
-        const hit = placed.some(
-          (p) => Math.abs(p.cx - cx) < (p.w + w) / 2 && Math.abs(p.labelY - labelY) < 13,
-        );
-        if (!hit) break;
-        labelY -= 13;
-      }
-      placed.push({ cx, w, labelY });
-      labelYBySlug.set(d.problem.slug, labelY);
-    }
-  }
+      .sort((a, b) => b.significance - a.significance)
+      .map((d) => {
+        const cx = x(d.age);
+        return {
+          key: d.problem.slug,
+          cx,
+          cy: y(d.significance),
+          width: labelWidth(deTeX(d.problem.shortName)),
+          anchor: labelAnchorAt(cx),
+        };
+      }),
+    {
+      minY: MARGIN.top,
+      maxY: MARGIN.top + PLOT_H,
+      minX: MARGIN.left,
+      maxX: VIEW_W - MARGIN.right,
+      // Every drawn dot is an obstacle. Clearing only other labels left text
+      // written straight through the scatter.
+      points: shown.map((d) => ({ x: x(d.age), y: y(d.significance) })),
+    },
+  );
 
   return (
     <div>
@@ -199,11 +227,14 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
 
       <p className="mt-1 text-xs text-[var(--ink-muted)]">
         AI-estimated problem weight before the solve, 0-100 (Riemann = 100).
-        Hollow points are claimed solutions still under review. Click a point
-        to open it.
+        Hollow points are claimed solutions still under review. Click a point to
+        open it.
       </p>
 
-      <div className="relative mt-3" style={{ aspectRatio: `${VIEW_W} / ${VIEW_H}` }}>
+      <div
+        className="relative mt-3"
+        style={{ aspectRatio: `${VIEW_W} / ${VIEW_H}` }}
+      >
         <svg
           viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
           className="h-full w-full overflow-visible"
@@ -249,7 +280,11 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
               y={VIEW_H - MARGIN.bottom + 20}
               textAnchor="middle"
               className="font-mono"
-              style={{ fontSize: 12, fill: "var(--ink-muted)", fontVariantNumeric: "tabular-nums" }}
+              style={{
+                fontSize: 12,
+                fill: "var(--ink-muted)",
+                fontVariantNumeric: "tabular-nums",
+              }}
             >
               {t}
             </text>
@@ -272,7 +307,11 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
               dominantBaseline="middle"
               textAnchor="end"
               className="font-mono"
-              style={{ fontSize: 12, fill: "var(--ink-muted)", fontVariantNumeric: "tabular-nums" }}
+              style={{
+                fontSize: 12,
+                fill: "var(--ink-muted)",
+                fontVariantNumeric: "tabular-nums",
+              }}
             >
               {t}
             </text>
@@ -298,8 +337,11 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
             // viewBox - the svg has overflow visible, and a centred label on
             // an edge point would poke out of the card (and on phones, widen
             // the page).
-            const labelAnchor =
-              cx > VIEW_W - 100 ? "end" : cx < MARGIN.left + 100 ? "start" : "middle";
+            // Undefined when the packer found no clear slot: the label is
+            // dropped, not stacked on top of a neighbour. When it is defined
+            // it carries its own x and anchor, because a label may be placed
+            // beside its dot rather than over it.
+            const label = labelYBySlug.get(problem.slug);
             return (
               <g
                 key={problem.slug}
@@ -312,7 +354,8 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
                 onBlur={() => setActiveSlug(null)}
                 onClick={() => router.push(`/problem/${problem.slug}`)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") router.push(`/problem/${problem.slug}`);
+                  if (e.key === "Enter")
+                    router.push(`/problem/${problem.slug}`);
                 }}
                 style={{ cursor: "pointer", outline: "none" }}
               >
@@ -339,11 +382,11 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
                     strokeWidth={isOutlier ? 2 : 1}
                   />
                 )}
-                {isOutlier && (
+                {isOutlier && label && (
                   <text
-                    x={cx}
-                    y={labelYBySlug.get(problem.slug) ?? cy - 12}
-                    textAnchor={labelAnchor}
+                    x={label.x}
+                    y={label.y}
+                    textAnchor={label.anchor}
                     // No halo. It used to paint a 3.5px paper-coloured stroke
                     // behind the glyphs so labels stayed legible over
                     // gridlines, which worked until Chrome's auto-dark got
@@ -375,9 +418,13 @@ export function ReferencesChart({ problems }: { problems: ChartProblem[] }) {
               transform: "translate(-50%, calc(-100% - 16px))",
             }}
           >
-            <p className="font-serif text-sm text-[var(--ink)]"><TeX>{active.problem.name}</TeX></p>
+            <p className="font-serif text-sm text-[var(--ink)]">
+              <TeX>{active.problem.name}</TeX>
+            </p>
             <p className="mt-1 text-[var(--ink-secondary)]">
-              {active.problem.field ?? SOLVE_TYPE_LABEL[active.problem.solveType] ?? active.problem.solveType}
+              {active.problem.field ??
+                SOLVE_TYPE_LABEL[active.problem.solveType] ??
+                active.problem.solveType}
             </p>
             <dl className="mt-2 grid grid-cols-2 gap-x-2 gap-y-1 font-mono text-[var(--ink-secondary)]">
               <dt className="text-[var(--ink-muted)]">Age</dt>

--- a/src/lib/monthly-peak.test.ts
+++ b/src/lib/monthly-peak.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  eligible,
+  monthlyPeaks,
+  recordMonths,
+  runningPeak,
+} from "@/lib/monthly-peak";
+import type { ChartProblem } from "@/lib/problems";
+
+const p = (
+  slug: string,
+  solveDate: string,
+  significance: number | null,
+  extra: Partial<ChartProblem> = {},
+): ChartProblem =>
+  ({
+    slug,
+    name: slug,
+    shortName: slug,
+    problemNumber: null,
+    field: "",
+    fieldGroup: "Analysis",
+    solveDate,
+    solveType: "proved",
+    resolution: "resolved",
+    resolutionMethod: "argument",
+    aiContribution: "ai-discovered",
+    model: "",
+    modelMaker: "",
+    verification: "unreviewed",
+    yearPosed: 2000,
+    significance,
+    ...extra,
+  }) as ChartProblem;
+
+describe("eligible", () => {
+  it("takes resolved and candidate entries", () => {
+    expect(eligible(p("a", "2026-01-05", 10))).toBe(true);
+    expect(
+      eligible(p("b", "2026-01-05", 10, { resolution: "candidate" })),
+    ).toBe(true);
+  });
+
+  it("rejects partials and variants, which have no moment of resolution", () => {
+    expect(eligible(p("c", "2026-01-05", 10, { resolution: "partial" }))).toBe(
+      false,
+    );
+    expect(eligible(p("d", "2026-01-05", 10, { resolution: "variant" }))).toBe(
+      false,
+    );
+  });
+
+  it("rejects an entry with no score or no date", () => {
+    expect(eligible(p("e", "2026-01-05", null))).toBe(false);
+    expect(eligible(p("f", "", 10))).toBe(false);
+  });
+});
+
+describe("monthlyPeaks", () => {
+  it("keeps the heaviest entry of each month", () => {
+    const rows = monthlyPeaks(
+      [
+        p("small", "2026-01-04", 10),
+        p("big", "2026-01-20", 70),
+        p("mid", "2026-01-28", 40),
+      ],
+      "2026-01-31",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].top?.slug).toBe("big");
+    expect(rows[0].significance).toBe(70);
+  });
+
+  it("keeps empty months as gaps so the axis stays a timeline", () => {
+    const rows = monthlyPeaks(
+      [p("a", "2026-01-10", 20), p("b", "2026-04-10", 30)],
+      "2026-04-30",
+    );
+    expect(rows.map((r) => r.month)).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+      "2026-04",
+    ]);
+    expect(rows[1].top).toBeNull();
+    expect(rows[1].significance).toBe(0);
+  });
+
+  it("runs to today, not to the last solve", () => {
+    // A quiet stretch is information. Ending the axis at the last result
+    // would imply the record ended with it.
+    const rows = monthlyPeaks([p("a", "2026-01-10", 20)], "2026-05-15");
+    expect(rows[rows.length - 1].month).toBe("2026-05");
+    expect(rows[rows.length - 1].top).toBeNull();
+  });
+
+  it("breaks ties towards the earlier solve", () => {
+    const rows = monthlyPeaks(
+      [p("later", "2026-02-20", 50), p("earlier", "2026-02-03", 50)],
+      "2026-02-28",
+    );
+    expect(rows[0].top?.slug).toBe("earlier");
+  });
+
+  it("returns nothing when no entry qualifies", () => {
+    expect(monthlyPeaks([p("a", "2026-01-01", null)], "2026-02-01")).toEqual(
+      [],
+    );
+  });
+
+  it("survives a solve dated after today", () => {
+    // Clock skew or a mis-keyed date should not collapse the range.
+    const rows = monthlyPeaks([p("a", "2027-01-10", 20)], "2026-05-15");
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0].top?.slug).toBe("a");
+  });
+});
+
+describe("runningPeak", () => {
+  it("never falls", () => {
+    const rows = monthlyPeaks(
+      [
+        p("a", "2026-01-10", 30),
+        p("b", "2026-02-10", 10),
+        p("c", "2026-03-10", 55),
+      ],
+      "2026-03-31",
+    );
+    expect(runningPeak(rows)).toEqual([30, 30, 55]);
+  });
+
+  it("holds its level across empty months", () => {
+    const rows = monthlyPeaks(
+      [p("a", "2026-01-10", 30), p("b", "2026-03-10", 20)],
+      "2026-03-31",
+    );
+    expect(runningPeak(rows)).toEqual([30, 30, 30]);
+  });
+});
+
+describe("recordMonths", () => {
+  it("marks only the months that set a new high", () => {
+    const rows = monthlyPeaks(
+      [
+        p("a", "2026-01-10", 30),
+        p("b", "2026-02-10", 20),
+        p("c", "2026-03-10", 55),
+        p("d", "2026-04-10", 55),
+      ],
+      "2026-04-30",
+    );
+    expect([...recordMonths(rows)].sort()).toEqual(["2026-01", "2026-03"]);
+  });
+
+  it("does not mark an empty month", () => {
+    const rows = monthlyPeaks(
+      [p("a", "2026-01-10", 30), p("b", "2026-03-10", 40)],
+      "2026-03-31",
+    );
+    expect(recordMonths(rows).has("2026-02")).toBe(false);
+  });
+});

--- a/src/lib/monthly-peak.ts
+++ b/src/lib/monthly-peak.ts
@@ -1,0 +1,109 @@
+// "Most significant per month": for every month from the first solve to
+// today, the single heaviest problem resolved in it.
+//
+// The other time charts on /stats count things - entries per week, cumulative
+// totals, share by area - and all of them go up simply because the catalog
+// grows. This one cannot: a month's value is the weight of its best result,
+// so it only rises when something genuinely bigger lands. That makes it the
+// one chart on the page that shows a ceiling moving rather than a pile
+// getting taller, which is the actual claim the site exists to document.
+//
+// Months with nothing in them are kept as gaps rather than dropped, so the
+// x axis stays a real timeline: the run of empty months early on is part of
+// the story, not noise to be compressed away.
+
+import { bucketKey, bucketRange } from "@/lib/time-buckets";
+import type { ChartProblem } from "@/lib/problems";
+
+export interface MonthPeak {
+  /// "YYYY-MM".
+  month: string;
+  /// The heaviest entry resolved this month, or null if the month is empty.
+  top: ChartProblem | null;
+  /// Its significance, or 0 for an empty month.
+  significance: number;
+}
+
+/// Entries that can appear on this chart at all: a resolution that means the
+/// problem is actually settled, a solve date to place it, and a score to
+/// plot. Partials and variants are excluded for the same reason they are
+/// excluded from the age scatter - a bound improvement has no single moment
+/// of resolution - and candidates are kept because a claimed solution under
+/// review is still the biggest thing that happened that month.
+export function eligible(p: ChartProblem): boolean {
+  return (
+    (p.resolution === "resolved" || p.resolution === "candidate") &&
+    typeof p.solveDate === "string" &&
+    p.solveDate.length >= 7 &&
+    typeof p.significance === "number"
+  );
+}
+
+/**
+ * Bucket problems by solve month and keep the heaviest of each.
+ *
+ * `today` bounds the right edge so the axis ends at the present rather than
+ * at the last solve, which matters when nothing has landed for a few weeks:
+ * a chart that stops at the last result implies the record stopped too.
+ */
+export function monthlyPeaks(
+  problems: ChartProblem[],
+  today: string,
+): MonthPeak[] {
+  const usable = problems.filter(eligible);
+  if (usable.length === 0) return [];
+
+  const best = new Map<string, ChartProblem>();
+  for (const p of usable) {
+    const key = bucketKey(p.solveDate as string, "month");
+    const prev = best.get(key);
+    // Ties break towards the earlier solve date, so the month credits
+    // whichever result got there first.
+    if (
+      !prev ||
+      (p.significance as number) > (prev.significance as number) ||
+      ((p.significance as number) === (prev.significance as number) &&
+        (p.solveDate as string) < (prev.solveDate as string))
+    ) {
+      best.set(key, p);
+    }
+  }
+
+  const first = [...best.keys()].sort()[0];
+  const last = bucketKey(today, "month");
+  // A solve dated in the future would otherwise produce an empty range.
+  const end = last >= first ? last : [...best.keys()].sort().slice(-1)[0];
+
+  return bucketRange(first, end, "month").map((month) => {
+    const top = best.get(month) ?? null;
+    return {
+      month,
+      top,
+      significance: top ? (top.significance as number) : 0,
+    };
+  });
+}
+
+/// The running maximum, so the chart can draw the record line: the highest
+/// significance seen up to and including each month. Never falls.
+export function runningPeak(rows: MonthPeak[]): number[] {
+  let best = 0;
+  return rows.map((r) => {
+    best = Math.max(best, r.significance);
+    return best;
+  });
+}
+
+/// Months whose peak set a new all-time high. These are the only months worth
+/// labelling: everything else is noise against the record line.
+export function recordMonths(rows: MonthPeak[]): Set<string> {
+  const out = new Set<string>();
+  let best = 0;
+  for (const r of rows) {
+    if (r.top && r.significance > best) {
+      best = r.significance;
+      out.add(r.month);
+    }
+  }
+  return out;
+}

--- a/src/lib/scatter-labels.test.ts
+++ b/src/lib/scatter-labels.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import {
+  extent,
+  labelWidth,
+  placeLabels,
+  type LabelInput,
+  type Placement,
+} from "@/lib/scatter-labels";
+
+const BOUNDS = { minY: 34, maxY: 316, minX: 56, maxX: 616 };
+
+const at = (key: string, cx: number, cy: number, width = 60): LabelInput => ({
+  key,
+  cx,
+  cy,
+  width,
+  anchor: "middle",
+});
+
+/// Do two placed labels overlap? The property every test below really cares
+/// about, expressed once.
+function overlaps(a: LabelInput, ap: Placement, b: LabelInput, bp: Placement) {
+  const [a0, a1] = extent(ap.x, a.width, ap.anchor);
+  const [b0, b1] = extent(bp.x, b.width, bp.anchor);
+  return Math.abs(ap.y - bp.y) < 13 && a0 < b1 && a1 > b0;
+}
+
+describe("placeLabels", () => {
+  it("places an isolated label just above its point", () => {
+    const out = placeLabels([at("a", 200, 200)], BOUNDS);
+    expect(out.get("a")?.y).toBe(188);
+  });
+
+  it("lifts the second of two colliding labels instead of overprinting", () => {
+    const a = at("a", 200, 200);
+    const b = at("b", 210, 200);
+    const out = placeLabels([a, b], BOUNDS);
+    expect(out.size).toBe(2);
+    expect(overlaps(a, out.get("a")!, b, out.get("b")!)).toBe(false);
+  });
+
+  it("leaves labels alone when they are far apart horizontally", () => {
+    const out = placeLabels([at("a", 100, 200), at("b", 400, 200)], BOUNDS);
+    expect(out.get("a")?.y).toBe(188);
+    expect(out.get("b")?.y).toBe(188);
+  });
+
+  it("DROPS a label rather than overprint when the ladder is exhausted", () => {
+    // Twenty labels stacked on one point cannot all fit. The old stacker gave
+    // up after six lifts and drew them anyway; this is the regression that
+    // produced the unreadable pile at the top of the chart.
+    const many = Array.from({ length: 20 }, (_, i) => at(`n${i}`, 200, 200));
+    const out = placeLabels(many, BOUNDS);
+    expect(out.size).toBeLessThan(20);
+    expect(out.size).toBeGreaterThan(0);
+    // Whatever survived must be mutually clear.
+    const kept = many.filter((m) => out.has(m.key));
+    for (let i = 0; i < kept.length; i++)
+      for (let j = i + 1; j < kept.length; j++)
+        expect(
+          overlaps(
+            kept[i],
+            out.get(kept[i].key)!,
+            kept[j],
+            out.get(kept[j].key)!,
+          ),
+        ).toBe(false);
+  });
+
+  it("never places a label above the top margin", () => {
+    // A point at the very top of the plot has almost no headroom, so most of
+    // the ladder is out of bounds; anything placed must still be inside.
+    const many = Array.from({ length: 8 }, (_, i) => at(`n${i}`, 200, 40));
+    const out = placeLabels(many, BOUNDS);
+    for (const p of out.values())
+      expect(p.y).toBeGreaterThanOrEqual(BOUNDS.minY);
+  });
+
+  it("never places a label below the baseline", () => {
+    const many = Array.from({ length: 8 }, (_, i) => at(`n${i}`, 200, 310));
+    const out = placeLabels(many, BOUNDS);
+    for (const p of out.values()) expect(p.y).toBeLessThanOrEqual(BOUNDS.maxY);
+  });
+
+  it("falls below the point when there is no room above", () => {
+    // Pinned at the ceiling: the only free slots are the downward rungs.
+    const out = placeLabels([at("a", 200, 36)], BOUNDS);
+    expect(out.get("a")?.y).toBeGreaterThan(36);
+  });
+
+  it("packs in the caller's order, so earlier items win the slot", () => {
+    const first = at("first", 200, 200);
+    const second = at("second", 205, 200);
+    const out = placeLabels([first, second], BOUNDS);
+    // The first keeps the slot nearest its point.
+    expect(out.get("first")?.y).toBe(188);
+    expect(out.get("second")?.y).not.toBe(188);
+  });
+
+  it("avoids writing a label through a plotted point", () => {
+    // A dot sitting exactly where the first rung would put the text. The
+    // first version of this fix cleared label-vs-label but happily punched
+    // points through the middle of words.
+    const a = at("a", 200, 200);
+    const out = placeLabels([a], { ...BOUNDS, points: [{ x: 200, y: 188 }] });
+    expect(out.get("a")?.y).not.toBe(188);
+  });
+
+  it("does not treat a label's own point as an obstacle", () => {
+    const a = at("a", 200, 200);
+    const out = placeLabels([a], { ...BOUNDS, points: [{ x: 200, y: 200 }] });
+    expect(out.get("a")?.y).toBe(188);
+  });
+
+  it("ignores points far from the label box", () => {
+    const a = at("a", 200, 200);
+    const out = placeLabels([a], { ...BOUNDS, points: [{ x: 400, y: 188 }] });
+    expect(out.get("a")?.y).toBe(188);
+  });
+
+  it("respects the anchor when testing overlap", () => {
+    // Two points 40 apart with 60-wide labels: centred they overlap, but
+    // anchored away from each other they do not, and both should sit on the
+    // first rung. Testing edge labels as if centred is what let them collide.
+    const a: LabelInput = {
+      key: "a",
+      cx: 200,
+      cy: 200,
+      width: 60,
+      anchor: "end",
+    };
+    const b: LabelInput = {
+      key: "b",
+      cx: 240,
+      cy: 200,
+      width: 60,
+      anchor: "start",
+    };
+    const out = placeLabels([a, b], BOUNDS);
+    expect(out.get("a")?.y).toBe(188);
+    expect(out.get("b")?.y).toBe(188);
+  });
+
+  it("keeps every label inside the horizontal bounds", () => {
+    // A wide label on a point near the right edge must not run off the plot,
+    // whatever slot it lands in.
+    const wide: LabelInput = {
+      key: "w",
+      cx: 600,
+      cy: 200,
+      width: 140,
+      anchor: "end",
+    };
+    const out = placeLabels([wide], BOUNDS);
+    const p = out.get("w");
+    if (p) {
+      const [x0, x1] = extent(p.x, wide.width, p.anchor);
+      expect(x0).toBeGreaterThanOrEqual(BOUNDS.minX);
+      expect(x1).toBeLessThanOrEqual(BOUNDS.maxX);
+    }
+  });
+
+  it("puts a label beside its point when the space above is taken", () => {
+    // The crowded band runs diagonally, so points there stack vertically and
+    // the free space is sideways. Blocking every vertical slot with dots
+    // should push the label to a side slot rather than drop it.
+    const a = at("a", 300, 200, 50);
+    const blockers = [-12, -25, 18, -38, 31, -51].map((dy) => ({
+      x: 300,
+      y: 200 + dy,
+    }));
+    const out = placeLabels([a], { ...BOUNDS, points: blockers });
+    const p = out.get("a");
+    expect(p).toBeDefined();
+    expect(p!.anchor).not.toBe("middle");
+    expect(p!.x).not.toBe(300);
+  });
+
+  it("recovers labels that a vertical-only ladder would have dropped", () => {
+    // Five points stacked in a column, the shape the diagonal band makes.
+    // With only up/down slots most of these collide and get dropped; with
+    // side slots they fan out. This is the whole reason side slots exist.
+    const column = [0, 1, 2, 3, 4].map((i) =>
+      at(`c${i}`, 300, 150 + i * 14, 70),
+    );
+    const out = placeLabels(column, {
+      ...BOUNDS,
+      points: column.map((c) => ({ x: c.cx, y: c.cy })),
+    });
+    expect(out.size).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe("labelWidth", () => {
+  it("grows with the text", () => {
+    expect(labelWidth("Köthe Conjecture")).toBeGreaterThan(labelWidth("KLS"));
+  });
+
+  it("is generous rather than tight", () => {
+    // 16 characters at 12px should not be estimated under ~100px; an
+    // under-estimate is what lets neighbours touch.
+    expect(labelWidth("Köthe Conjecture")).toBeGreaterThan(100);
+  });
+});
+
+describe("extent", () => {
+  it("centres a middle-anchored label on its point", () => {
+    expect(extent(100, 40, "middle")).toEqual([80, 120]);
+  });
+
+  it("puts a start-anchored label entirely to the right", () => {
+    expect(extent(100, 40, "start")).toEqual([100, 140]);
+  });
+
+  it("puts an end-anchored label entirely to the left", () => {
+    expect(extent(100, 40, "end")).toEqual([60, 100]);
+  });
+});

--- a/src/lib/scatter-labels.ts
+++ b/src/lib/scatter-labels.ts
@@ -1,0 +1,163 @@
+// Label placement for the significance scatter on /stats.
+//
+// The chart labels every point above a significance threshold. As the catalog
+// filled up, the labelled band stopped being "a few outliers in the sparse
+// corner" and became roughly two dozen names inside one crowded rectangle,
+// and the old greedy stacker printed them on top of each other: it lifted a
+// label by one row per collision but gave up after six lifts and drew the
+// label anyway, so the densest region - exactly the region that needed help -
+// got the worst pile.
+//
+// Three rules replace that:
+//
+//   - Search a ladder of candidate slots: above the point, below it, and
+//     BESIDE it. Sideways matters more than it sounds. The crowded band runs
+//     diagonally, so points there are stacked vertically at similar x, and
+//     the free space is to their left and right rather than overhead.
+//   - Treat the plotted dots as obstacles too, not just other labels. Text
+//     written through the scatter is as unreadable as text written through
+//     text.
+//   - If nothing is free, DROP the label rather than overprint. A dropped
+//     label costs one name; an overprinted one costs every name under it,
+//     and the points stay hover- and click-discoverable either way.
+//
+// Kept out of the component and free of React so the packing can be tested
+// directly, which is the only way to know a change here helps rather than
+// rearranges the mess.
+
+export type LabelAnchor = "start" | "middle" | "end";
+
+export interface LabelInput {
+  key: string;
+  /// Point centre, in viewBox units.
+  cx: number;
+  cy: number;
+  /// Estimated rendered text width.
+  width: number;
+  /// Anchor to use for the slots directly above and below the point. Edge
+  /// points anchor inward so the text stays inside the viewBox.
+  anchor: LabelAnchor;
+}
+
+export interface Placement {
+  x: number;
+  y: number;
+  anchor: LabelAnchor;
+}
+
+export interface PlaceOptions {
+  /// Labels may not climb above this line, nor fall below maxY.
+  minY: number;
+  maxY: number;
+  /// Nor extend outside these, which are the plot's horizontal bounds.
+  minX: number;
+  maxX: number;
+  /// Row height, and the vertical clearance two labels need.
+  rowH?: number;
+  /// Every plotted dot, as an obstacle.
+  points?: { x: number; y: number }[];
+  /// Dot radius to keep clear of.
+  pointR?: number;
+}
+
+/// Candidate slots, in preference order, as offsets from the point. `side`
+/// overrides the label's own anchor: a label placed to the right of its dot
+/// must anchor at its left edge whatever the point's position implies.
+///
+/// Above first, because a label reads as belonging to the dot beneath it.
+/// Then beside, then below, then further out.
+const LADDER: { dx: number; dy: number; side?: LabelAnchor }[] = [
+  { dx: 0, dy: -12 },
+  { dx: 8, dy: 4, side: "start" },
+  { dx: -8, dy: 4, side: "end" },
+  { dx: 0, dy: -25 },
+  { dx: 0, dy: 18 },
+  { dx: 8, dy: -8, side: "start" },
+  { dx: -8, dy: -8, side: "end" },
+  { dx: 0, dy: -38 },
+  { dx: 0, dy: 31 },
+  { dx: 8, dy: 16, side: "start" },
+  { dx: -8, dy: 16, side: "end" },
+  { dx: 0, dy: -51 },
+];
+
+/// Horizontal extent of a label drawn at `x` with the given anchor. The
+/// collision test has to agree with what the renderer actually draws: an
+/// edge-anchored label occupies one side of its point, not both, and testing
+/// it as centred was letting edge labels overlap their neighbours.
+export function extent(
+  x: number,
+  width: number,
+  anchor: LabelAnchor,
+): [number, number] {
+  if (anchor === "start") return [x, x + width];
+  if (anchor === "end") return [x - width, x];
+  return [x - width / 2, x + width / 2];
+}
+
+/**
+ * Choose a position for each label, or leave it out when there is no room.
+ *
+ * Points are packed in the caller's order, so pass them most-important first:
+ * whoever comes first gets the slot, and the ones dropped are the ones the
+ * caller cared least about.
+ */
+export function placeLabels(
+  items: LabelInput[],
+  {
+    minY,
+    maxY,
+    minX,
+    maxX,
+    rowH = 13,
+    points = [],
+    pointR = 5,
+  }: PlaceOptions,
+): Map<string, Placement> {
+  const out = new Map<string, Placement>();
+  const placed: { x0: number; x1: number; y: number }[] = [];
+
+  for (const item of items) {
+    for (const slot of LADDER) {
+      const anchor = slot.side ?? item.anchor;
+      const x = item.cx + slot.dx;
+      const y = item.cy + slot.dy;
+      if (y < minY || y > maxY) continue;
+
+      const [x0, x1] = extent(x, item.width, anchor);
+      if (x0 < minX || x1 > maxX) continue;
+
+      // A 2px horizontal breathing gap: touching labels read as one string.
+      const clash = placed.some(
+        (p) => Math.abs(p.y - y) < rowH && x0 < p.x1 + 2 && x1 > p.x0 - 2,
+      );
+      if (clash) continue;
+
+      // The glyph box for a 12px label sits roughly from y-9 to y+3 around
+      // the baseline. A dot inside that box lands in the middle of a word.
+      // The label's own point is exempt: it is what the label names, and a
+      // beside-slot deliberately sits next to it.
+      const onPoint = points.some(
+        (p) =>
+          !(p.x === item.cx && p.y === item.cy) &&
+          p.x + pointR > x0 &&
+          p.x - pointR < x1 &&
+          p.y + pointR > y - 9 &&
+          p.y - pointR < y + 3,
+      );
+      if (onPoint) continue;
+
+      placed.push({ x0, x1, y });
+      out.set(item.key, { x, y, anchor });
+      break;
+    }
+  }
+  return out;
+}
+
+/// Rendered width of a label, estimated from character count. Deliberately a
+/// little generous: under-estimating width is what lets two labels touch, and
+/// a slightly wide box only costs an occasional extra drop.
+export function labelWidth(text: string, fontSize = 12): number {
+  return text.length * fontSize * 0.55 + 6;
+}


### PR DESCRIPTION
Release of the /stats chart work. Six commits are ahead of production, but only one of them contains runtime code - the other five are review scripts and records that changed nothing on the site.

## What actually reaches the site

**#57 — scatter label overlap fixed, and a new chart.**

The significance scatter was printing roughly two dozen names on top of each other, over the dots, and out of the card into the description text. Its stacker gave up after six lifts and drew the label anyway, and it laid out over every point rather than the visible ones, so filtering never decluttered. Replaced with a tested packer: slots above, below and beside each point, dots treated as obstacles, bounds on all four sides, and a dropped label rather than an overprinted one. 7 readable labels became 14.

**New card: "Most significant result per month."** The heaviest problem resolved in each month from the first solve to today, with a running-best step line and only the record months labelled. Unlike every other time chart on the page it does not rise with volume - a month is worth its best result, so it moves only when something bigger lands. On production data it reads as six records ending at Navier-Stokes, 87.

## What does not reach the site

#51, #52, #53, #54, #56 - review scripts and their reasoning. The entries and decisions they describe were applied directly to the production database days ago and are already live.

## Verification

- `npm run typecheck` clean, `npm run lint` 0 errors, 128 tests pass (28 new)
- Built against production data and screenshotted `/stats` headlessly at each step, which is how both rendering defects were found: text written through the scatter dots, and month labels drawn through the bottoms of the bars

## Manual check after deploy

1. `/stats` — the scatter's labels should be legible with none overlapping a label or a dot, Navier-Stokes included at the top of the scale.
2. Click through Any / Discovered / Co-developed / Assisted on that scatter. Placement should re-pack per filter; this path was broken before and is the likeliest to regress.
3. The new card, second in the grid. Hover across the months to see each month's result named under the chart, and click one to open the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
