### PR TITLE
Release: entry editability fix, and three days of catalog work

### DIFF
--- a/scripts/add-dbn-frontier-2026-09-12.ts
+++ b/scripts/add-dbn-frontier-2026-09-12.ts
@@ -1,0 +1,330 @@
+// Adds the de Bruijn-Newman frontier: upper bounds on Lambda.
+//
+// Asked for after Gomila's Lambda <= 0.1787854 was declined as an entry on
+// 12 September. The decline was right that it is a record rather than the
+// resolution of a posed question, and wrong about where records go - the
+// catalog files them as entries with resolution partial, and a frontier is
+// the staircase those entries sit on. This builds the staircase.
+//
+// The quantity is the de Bruijn-Newman constant: the threshold Lambda such
+// that the zeros of the heat-flow deformation H_t of the Riemann xi function
+// are all real exactly when t >= Lambda. Lambda <= 0 IS the Riemann
+// hypothesis, and Rodgers and Tao proved Lambda >= 0 in 2018, so the
+// remaining question is how far the upper bound can be pushed toward zero.
+// That makes this the rare frontier whose finish line is a Millennium
+// problem, and the rows since 2019 are a real race.
+//
+// Direction is "min": a smaller upper bound is better.
+//
+// WHAT WAS VERIFIED, ROW BY ROW, and this matters because two rows could not
+// be opened from this machine and are marked as such rather than asserted:
+//
+//   1950  de Bruijn, Lambda <= 1/2. Classical and universally cited; not
+//         independently opened here.
+//   2009  Ki, Kim and Lee, Lambda < 1/2 strictly. Also classical. Numerically
+//         the same 0.5, which is the point: the bound did not move for
+//         fifty-nine years, and the chart shows that flat stretch honestly.
+//   2019  Polymath15, Lambda <= 0.22. arXiv:1904.12438 read here: title,
+//         authorship (D.H.J. Polymath) and abstract all confirm it.
+//   2020  Lambda <= 0.2, the same Polymath15 criterion instantiated at Platt
+//         and Trudgian's verified height. Platt-Trudgian arXiv:2004.09765 was
+//         read here and states RH verified to height 3*10^12. The 0.2 figure
+//         itself is recorded on the Polymath project wiki and in Tao's
+//         commentary, NEITHER OF WHICH COULD BE OPENED FROM HERE (DNS
+//         failure), so the row is attributed to the mechanism and the note
+//         says where the statement lives. Gomila's own package corroborates
+//         it: his referee report checks that the criterion needs verified
+//         height X/2 = 3000000092913.5 and that Platt-Trudgian Theorem 1
+//         reaches 3000175332800.
+//   2026  Mosaic Intelligence, Lambda <= 0.1875, Zenodo 21175533. Zenodo
+//         returned 403 to this machine, so the row is transcribed from
+//         Gomila's UPSTREAM.md artifact lock, which records the DOI, the
+//         2026-07-03 publication date, the CC BY 4.0 licence and SHA-256
+//         hashes of the two files. Marked candidate: an unreviewed claim.
+//   2026  Gomila, Lambda <= 0.1787854 = 893927/5000000, at exact parameters
+//         X = 6000000185827, t0 = 129/800, y0^2 = 87677/2500000. The
+//         repository was read here: the release tag, the sealed manifest, the
+//         external referee report (an adversarial AI panel, explicitly "not a
+//         substitute for human expert peer review", which found no fatal
+//         defect and left three items needing human sign-off), and the
+//         bibliography. Marked candidate.
+//
+// The last two rows are candidates, so they are drawn hollow and neither is
+// the frontier's headline value. That is the honest picture: the standing
+// reviewed record is 0.2, with two unreviewed claims below it.
+//
+// No row links to a catalog entry. Gomila's submission was declined on form
+// defects and may be resubmitted; if it is published, add problemSlug to the
+// last row so the frontier inherits its model and verification.
+//
+// Frontier and FrontierRow have NO form validator - only the database column
+// widths - so this script checks every one of them before writing, which is
+// how the C11 frontier's P2000 failure is not repeated.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+
+const prisma = guardedPrisma();
+const APPLY = process.argv.includes("--apply");
+const LINT = process.argv.includes("--lint");
+
+const SLUG = "de-bruijn-newman-constant";
+
+const FRONTIER = {
+  slug: SLUG,
+  name: "Upper bounds for the de Bruijn-Newman constant",
+  // shortName renders RAW on /frontiers and in FrontierMembership, so plain
+  // text with a Unicode capital lambda, never TeX.
+  shortName: "de Bruijn-Newman Λ",
+  quantity: "the de Bruijn-Newman constant $\\Lambda$",
+  statement:
+    "For each real $t$ the entire function $H_t$ is the heat-flow deformation of the Riemann $\\xi$ function, and de Bruijn and Newman showed there is a finite constant $\\Lambda$ such that the zeros of $H_t$ are all real exactly when $t\\ge\\Lambda$. The Riemann hypothesis is equivalent to $\\Lambda\\le 0$, and Rodgers and Tao proved Newman's complementary conjecture $\\Lambda\\ge 0$ in 2018, so the constant is pinned below at zero and the open question is how far the upper bound can be pushed toward it. This frontier tracks that upper bound. Reaching $0$ would prove the Riemann hypothesis; nothing here claims to be near it.",
+  direction: "min",
+  field: "Analytic number theory; zeros of the Riemann zeta function",
+  fieldGroup: "Number theory",
+  significance: 45,
+  significanceNote:
+    "A named constant whose value decides the Riemann hypothesis: $\\Lambda\\le 0$ is equivalent to RH, and Newman's conjecture $\\Lambda\\ge 0$ was settled by Rodgers and Tao. The upper-bound race has its own literature and was the subject of a Polymath project led by Tao. Above the C11 capacity frontier at 35, whose audience is one subcommunity, and below the matrix multiplication exponent at 55, which the whole of theoretical computer science watches; the numerical bound on $\\Lambda$ is followed closely by analytic number theorists and known by name well beyond them.",
+  historyNote:
+    "Steps below 0.22 are the live race; the two 2026 rows are unreviewed claims and are drawn hollow, so the standing reviewed record on this staircase is 0.2. Two rows could not be opened from here and are marked in their notes: the 0.2 figure, whose primary statement is on the Polymath project wiki, and the 0.1875 claim, whose Zenodo record refused automated access and which is transcribed from the artifact lock in the 0.1787854 package. The 1950 and 2009 rows are classical and were not independently opened. Everything else was read at source.",
+};
+
+type Row = {
+  date: string;
+  valueTex: string;
+  valueShortTex?: string;
+  valueNumeric: number;
+  attribution: string;
+  sourceUrl: string;
+  status: string;
+  note?: string;
+  problemSlug?: string;
+};
+
+const ROWS: Row[] = [
+  {
+    date: "1950",
+    valueTex: "$\\le 1/2$",
+    valueShortTex: "0.5",
+    valueNumeric: 0.5,
+    attribution: "Nicolaas de Bruijn",
+    sourceUrl: "https://doi.org/10.1215/S0012-7094-50-01720-0",
+    status: "historical",
+    note: "De Bruijn's original bound, from the paper that introduced the deformation. Classical; cited here rather than opened.",
+  },
+  {
+    date: "2009",
+    valueTex: "$< 1/2$",
+    valueShortTex: "< 0.5",
+    valueNumeric: 0.5,
+    attribution: "Haseo Ki, Young-One Kim and Jungseob Lee",
+    sourceUrl: "https://doi.org/10.1112/jlms/jdp009",
+    status: "historical",
+    note: "Strict inequality, sharpening de Bruijn without moving the number. The flat stretch on this chart from 1950 to 2009 is real: fifty-nine years with no numerical improvement.",
+  },
+  {
+    date: "2019-04",
+    valueTex: "$\\le 0.22$",
+    valueShortTex: "0.22",
+    valueNumeric: 0.22,
+    attribution: "D.H.J. Polymath (Polymath15)",
+    sourceUrl: "https://arxiv.org/abs/1904.12438",
+    status: "historical",
+    note: "The Polymath15 project, which built an effective theory of the heat flow and instantiated it. This is the paper every later step uses: its Theorem 1.2 is the barrier criterion the 2026 claims plug exact parameters into.",
+  },
+  {
+    date: "2020-04",
+    valueTex: "$\\le 0.2$",
+    valueShortTex: "0.2",
+    valueNumeric: 0.2,
+    attribution:
+      "D.H.J. Polymath's criterion at Platt and Trudgian's verified height",
+    sourceUrl: "https://arxiv.org/abs/2004.09765",
+    status: "historical",
+    note: "Not a separate paper: the same Polymath15 criterion, fed by Platt and Trudgian's verification of RH to height 3e12. The linked source is that verification; the 0.2 figure is stated on the Polymath project wiki and in Tao's commentary, which could not be opened from here. This is the standing reviewed record.",
+  },
+  {
+    date: "2026-07-03",
+    valueTex: "$\\le 0.1875$",
+    valueShortTex: "0.1875",
+    valueNumeric: 0.1875,
+    attribution: "Mosaic Intelligence",
+    sourceUrl: "https://doi.org/10.5281/zenodo.21175533",
+    status: "candidate",
+    note: "A certified unconditional bound on a versioned Zenodo record, CC BY 4.0. Zenodo refused automated access from here, so this row is transcribed from the artifact lock in the 0.1787854 package, which pins the DOI, the date and SHA-256 hashes of both files. Unreviewed.",
+  },
+  {
+    date: "2026-08-20",
+    valueTex: "$\\le 893927/5000000 = 0.1787854$",
+    valueShortTex: "0.1787854",
+    valueNumeric: 0.1787854,
+    attribution: "Jude Gomila, with Claude and ChatGPT/Codex",
+    sourceUrl:
+      "https://github.com/judegomila/dbn-lambda-01787854-candidate-audit",
+    status: "candidate",
+    note: "Polymath15's Theorem 1.2 at exact parameters X = 6000000185827, t0 = 129/800, y0^2 = 87677/2500000, with fail-closed Arb interval certificates and a sealed manifest. Unconditional in form: no RH beyond the finite Platt-Trudgian height. Not peer reviewed; its referee report is an adversarial AI panel that calls itself no substitute for human review and leaves three items needing sign-off.",
+  },
+];
+
+/// Column widths from prisma/schema.prisma. These tables have no form and so
+/// no validator to mirror; a dry run that does not check them is worse than
+/// none, because it reports success and the write then fails with P2000,
+/// which names no column.
+const F_LIMITS: Record<string, number> = {
+  name: 120,
+  shortName: 60,
+  quantity: 300,
+  statement: 1500,
+  direction: 3,
+  field: 80,
+  significanceNote: 600,
+  historyNote: 600,
+};
+const R_LIMITS: Record<string, number> = {
+  date: 10,
+  valueTex: 200,
+  valueShortTex: 200,
+  attribution: 200,
+  status: 12,
+  note: 400,
+};
+
+/// Every column-width check, with no database. Runs FIRST, and under --lint
+/// runs alone: the first production dry run of this script spent a connection
+/// and a retry only to report one note at 409/400, which is a round trip the
+/// curator should never have to make for an answer that needs no database.
+function checkLengths(): number {
+  let over = 0;
+  console.log("field lengths:");
+  for (const [k, lim] of Object.entries(F_LIMITS)) {
+    const v = (FRONTIER as Record<string, unknown>)[k];
+    if (typeof v !== "string") continue;
+    const n = [...v.normalize("NFC")].length;
+    const bad = n > lim;
+    if (bad) over++;
+    console.log(`  frontier.${k.padEnd(17)} ${n}/${lim}${bad ? "  OVER" : ""}`);
+  }
+  for (const r of ROWS) {
+    for (const [k, lim] of Object.entries(R_LIMITS)) {
+      const v = (r as unknown as Record<string, unknown>)[k];
+      if (typeof v !== "string") continue;
+      const n = [...v.normalize("NFC")].length;
+      if (n > lim) {
+        over++;
+        console.log(`  row ${r.date} ${k}: ${n}/${lim}  OVER`);
+      }
+    }
+  }
+  console.log(over ? `${over} field(s) OVER` : "all field lengths ok");
+  return over;
+}
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const over = checkLengths();
+  if (LINT) {
+    process.exitCode = over ? 1 : 0;
+    return;
+  }
+  if (over) throw new Error(`${over} field(s) too long - nothing written`);
+
+  const db = await connectWithRetry();
+  console.log(`database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`);
+
+  const exists = await prisma.$queryRawUnsafe<{ slug: string }[]>(
+    `SELECT slug FROM "Frontier" WHERE slug = $1`,
+    SLUG,
+  );
+  console.log(`frontier ${SLUG}: ${exists.length ? "EXISTS" : "free"}`);
+  if (exists.length) throw new Error("slug taken");
+
+  const ids = new Map<string, string>();
+  for (const r of ROWS) {
+    if (!r.problemSlug) continue;
+    const p = await prisma.$queryRawUnsafe<{ id: string }[]>(
+      `SELECT id FROM "Problem" WHERE slug = $1 AND status = 'published'`,
+      r.problemSlug,
+    );
+    if (p.length !== 1) throw new Error(`entry not found: ${r.problemSlug}`);
+    ids.set(r.problemSlug, p[0].id);
+  }
+
+  console.log(
+    `\n${FRONTIER.shortName}  (${FRONTIER.direction})  sig=${FRONTIER.significance}`,
+  );
+  // "min" direction: best is smallest, so print worst-first to read as a
+  // descending staircase.
+  const sorted = [...ROWS].sort((a, b) => b.valueNumeric - a.valueNumeric);
+  for (const r of sorted) {
+    console.log(
+      `  ${r.date.padEnd(10)} ${String(r.valueNumeric).padEnd(12)} ${r.status.padEnd(11)} ${r.attribution.slice(0, 46)}`,
+    );
+  }
+  const best = sorted[sorted.length - 1];
+  const bestPublished = [...ROWS]
+    .filter((r) => r.status !== "candidate" && r.status !== "retracted")
+    .sort((a, b) => a.valueNumeric - b.valueNumeric)[0];
+  console.log(
+    `\n  headline (non-candidate): ${bestPublished.valueNumeric}  ${bestPublished.attribution.slice(0, 50)}`,
+  );
+  console.log(`  best claim overall      : ${best.valueNumeric}  (${best.status})`);
+
+  // A later row must not be worse than an earlier one, or a step is
+  // mis-transcribed.
+  const byDate = [...ROWS].sort((a, b) => a.date.localeCompare(b.date));
+  for (let i = 1; i < byDate.length; i++) {
+    if (byDate[i].valueNumeric > byDate[i - 1].valueNumeric)
+      console.log(
+        `  WARNING: ${byDate[i].date} (${byDate[i].valueNumeric}) is worse than ${byDate[i - 1].date} (${byDate[i - 1].valueNumeric})`,
+      );
+  }
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+
+  const created = await prisma.frontier.create({
+    data: {
+      ...FRONTIER,
+      rows: {
+        create: ROWS.map((r) => ({
+          date: r.date,
+          valueTex: r.valueTex,
+          valueShortTex: r.valueShortTex ?? null,
+          valueNumeric: r.valueNumeric,
+          attribution: r.attribution,
+          sourceUrl: r.sourceUrl,
+          status: r.status,
+          note: r.note ?? null,
+          problemId: r.problemSlug ? ids.get(r.problemSlug) : null,
+        })),
+      },
+    },
+    select: { id: true, slug: true, _count: { select: { rows: true } } },
+  });
+  console.log(
+    `\nAPPLIED. ${created.slug} created with ${created._count.rows} rows.`,
+  );
+  console.log("The frontier list lags by up to an hour, or until a deploy.");
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/audit-editability.ts
+++ b/scripts/audit-editability.ts
@@ -1,0 +1,171 @@
+// Can every published entry be saved through the edit form?
+//
+// Answered by running the form's OWN parser, not a reimplementation of its
+// rules. Each stored value is encoded exactly as the edit form encodes it -
+// links and relations as the JSON the form posts, lists comma-joined - and
+// handed to `parseField`, the function src/app/actions/update-problem.ts
+// calls on every field it receives. If parseField refuses a stored value,
+// the form would refuse it too.
+//
+// Two grades of finding, because they mean different things:
+//
+//   HARD    parseField rejects the stored value. Before the skip-untouched
+//           fix in update-problem.ts, one of these made the entry
+//           unsaveable outright, since the form posts every field. After
+//           it, only an edit to that specific field fails - but the value
+//           is still one the form would never have accepted, and the
+//           guarded client refuses to write more of them.
+//
+//   LATENT  A link points at the same document as the primary source. The
+//           action checks this only when links or the source are edited, so
+//           it never blocked an unrelated save - but a new submission with
+//           the same links is rejected, and editing this entry's links means
+//           fixing it first.
+//
+// Read-only. Exits non-zero when anything HARD remains, so it can gate a
+// release or run after a bulk script as proof rather than assumption.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+import { parseField } from "../src/lib/field-validation";
+import {
+  CURATOR_FIELDS,
+  EDITABLE_FIELDS,
+  encodeLinks,
+  sameDocument,
+} from "../src/lib/editable";
+import { encodeRelations } from "../src/lib/relation-kinds";
+import type { LinkRef } from "../src/lib/problems";
+
+const prisma = guardedPrisma();
+const SPECS = [...EDITABLE_FIELDS, ...CURATOR_FIELDS];
+const SCALAR_KEYS = [...new Set(SPECS.map((s) => s.key))].filter(
+  (k) => k !== "links" && k !== "relations",
+);
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+/// The string the edit form would post for a stored value.
+function asFormString(kind: string, value: unknown): string {
+  if (kind === "links") return encodeLinks((value as LinkRef[]) ?? []);
+  if (kind === "relations")
+    return encodeRelations(
+      (value as { to: string; kind: string; note: string }[]) ?? [],
+    );
+  if (value === null || value === undefined) return "";
+  if (Array.isArray(value)) return value.join(", ");
+  return String(value);
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const cols = SCALAR_KEYS.map((c) => `"${c}"`).join(", ");
+  const entries = await prisma.$queryRawUnsafe<Record<string, unknown>[]>(
+    `SELECT id, slug, ${cols} FROM "Problem" WHERE status = 'published' ORDER BY slug`,
+  );
+  const linkRows = await prisma.$queryRawUnsafe<
+    { problemId: string; label: string; url: string; kind: string | null }[]
+  >(
+    `SELECT "problemId", label, url, kind FROM "ProblemLink" ORDER BY "problemId", position`,
+  );
+  const relRows = await prisma.$queryRawUnsafe<
+    { fromId: string; to: string; kind: string; note: string }[]
+  >(
+    `SELECT r."fromId", t.slug AS "to", r.kind, r.note
+       FROM "ProblemRelation" r JOIN "Problem" t ON t.id = r."toId"
+      ORDER BY r."fromId", r.position`,
+  );
+  const links = new Map<string, LinkRef[]>();
+  for (const l of linkRows) {
+    const a = links.get(l.problemId) ?? [];
+    a.push({ label: l.label, url: l.url, kind: l.kind ?? undefined });
+    links.set(l.problemId, a);
+  }
+  const rels = new Map<string, { to: string; kind: string; note: string }[]>();
+  for (const r of relRows) {
+    const a = rels.get(r.fromId) ?? [];
+    a.push({ to: r.to, kind: r.kind, note: r.note });
+    rels.set(r.fromId, a);
+  }
+
+  const hard: { slug: string; field: string; error: string }[] = [];
+  const latent: { slug: string; label: string }[] = [];
+
+  for (const e of entries) {
+    const id = e.id as string;
+    const slug = e.slug as string;
+    const entryLinks = links.get(id) ?? [];
+    for (const spec of SPECS) {
+      const stored =
+        spec.kind === "links"
+          ? entryLinks
+          : spec.kind === "relations"
+            ? (rels.get(id) ?? [])
+            : e[spec.key];
+      const raw = asFormString(spec.kind, stored);
+      // The form never posts an empty optional field as an error, and a
+      // required field that is empty is a real finding.
+      const r = parseField(spec, raw, slug);
+      if (!r.ok) hard.push({ slug, field: spec.key, error: r.error });
+    }
+    const primary = e.sourceUrl as string | null;
+    if (primary)
+      for (const l of entryLinks)
+        if (sameDocument(l.url, primary)) latent.push({ slug, label: l.label });
+  }
+
+  const hardEntries = new Set(hard.map((h) => h.slug));
+  const latentEntries = new Set(latent.map((l) => l.slug));
+
+  console.log(`published entries checked: ${entries.length}`);
+  console.log(
+    `HARD   - a stored value the form's parser rejects: ${hard.length} in ${hardEntries.size} entries`,
+  );
+  console.log(
+    `LATENT - a link repeating the primary source:      ${latent.length} in ${latentEntries.size} entries`,
+  );
+
+  if (hard.length) {
+    const byField = new Map<string, number>();
+    for (const h of hard) byField.set(h.field, (byField.get(h.field) ?? 0) + 1);
+    console.log("\nHARD by field:");
+    for (const [f, n] of [...byField].sort((a, b) => b[1] - a[1]))
+      console.log(`  ${f.padEnd(20)} ${n}`);
+    console.log("\nHARD examples:");
+    for (const h of hard.slice(0, 15))
+      console.log(`  ${h.slug.slice(0, 50).padEnd(52)} ${h.field}: ${h.error}`);
+  }
+  if (latent.length) {
+    console.log("\nLATENT:");
+    for (const l of latent)
+      console.log(
+        `  ${l.slug.slice(0, 60).padEnd(62)} "${l.label.slice(0, 40)}"`,
+      );
+  }
+  if (!hard.length && !latent.length)
+    console.log(
+      "\nEvery published entry passes the form's own parser on every field.",
+    );
+
+  process.exitCode = hard.length ? 1 : 0;
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/contact-replies-2026-09-12.ts
+++ b/scripts/contact-replies-2026-09-12.ts
@@ -1,0 +1,478 @@
+// Answers all 18 open contact messages, 12 September 2026.
+//
+// These are `SiteMessage` rows - the /contact form coming IN - and the oldest
+// has been open since 5 August. A draft from 10 September
+// (scripts/inbox-replies-2026-09-10.ts, branch inbox-replies-2026-09-10) was
+// never applied, and it mostly closed these with internal notes rather than
+// answering anyone. This one answers them.
+//
+// Three routes, chosen by what the sender left us:
+//
+//   REPLIES  the sender has an account, so a DirectMessage reaches them
+//            in-app. Nine people, ten messages (Schleimer sent two).
+//   EMAILS   anonymous but left a reply address. The site cannot send mail,
+//            so the script prints a ready-to-send draft and marks the row
+//            handled. Five of these.
+//   NOTES    anonymous with no address. Nothing can be sent; the note records
+//            the substance so the point is not lost. Three of these.
+//
+// WHAT CHANGED SINCE THE OLD DRAFT, and it matters because three of these are
+// now answerable where they were not:
+//
+//   - GitHub sign-in EXISTS (src/auth.ts imports the GitHub provider and
+//     wires it with account linking). Olangu asked for a non-Google option
+//     and was told nothing; now there is a real answer.
+//   - The Ramachandra-Natarajan entry is ALREADY at Lean-checked with
+//     Olangu's repository linked and a curator source audit in its note. His
+//     request was actioned. He was never told.
+//   - The C11 frontier is live, with R10 as the headline, so Protti's
+//     question about R7 has a concrete home rather than a promise.
+//
+// VERIFICATION. Four accounts asked. Checked against the live profiles:
+// sjbevins and Saul Schleimer are already verified (Schleimer is also right
+// that he is not on Wikipedia, which is not the test). theabbie, Roy van
+// Rijn and Ryan Simonelli are not. Of those three, only Simonelli's evidence
+// is checkable from here and it is checkable both ways: his own page at
+// ryansimonelli.com/autonomous-philosophy.html links to
+// vibemathed.com/problem/signed-depth-relevance-of-subdl, and that entry was
+// submitted by the account asking. Verified here, with the note recording
+// exactly that. The other two hinge on whether their account email matches
+// the address on a LinkedIn or personal page, which this script cannot see
+// but the curator can: the dry run PRINTS each account's email next to the
+// claim so the call can be made in the moment.
+//
+// Dry run by default. Pass --apply to send. Production writes are the
+// curator's to run.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+import { MESSAGE_MAX } from "../src/lib/messages";
+
+const prisma = guardedPrisma();
+const APPLY = process.argv.includes("--apply");
+const LINT = process.argv.includes("--lint");
+
+/// The sender has an account: reply in-app and mark the row handled.
+/// `ids` is every SiteMessage this one reply answers.
+///
+/// The recipient is resolved through the SiteMessage's own `userId`, never
+/// through a pseudonym: `userName` on the row is a snapshot taken when the
+/// message was sent, and the first production run of this script died on
+/// "no account for theabbie" because that snapshot no longer matches any
+/// pseudonym. The foreign key does not rot.
+type Reply = { ids: string[]; who: string; body: string };
+
+/// Anonymous with a reply address: mark handled, print a draft to send.
+type Email = { id: string; who: string; to: string; subject: string; body: string };
+
+/// Anonymous with no address: mark handled, record what would have been said.
+type Note = { id: string; who: string; note: string };
+
+const REPLIES: Reply[] = [
+  {
+    ids: ["afefa2e4"],
+    who: "GoldenMongoose827",
+    body: `Thank you for this, and sorry it sat unanswered for so long.
+
+Not quite the right field, but no harm done. The citation URL belongs with the citation count: it records where that number was read, so it wants a Google Scholar or Semantic Scholar page rather than an encyclopedia article. Wikipedia presence is tracked separately, in its own field that counts how many language editions carry an article dedicated to the problem - it is used as a rough renown check and as an honesty check against the significance score, and it is a curator measurement rather than something a submitter fills in.
+
+So the right move for a problem with a Wikipedia article is to say so, and a curator sets the count. If you tell me which entry you meant, I will set it properly. Finding the article is the useful part; which box it goes in is our problem, not yours.`,
+  },
+  {
+    ids: ["2a3e657e"],
+    who: "HiddenHawk615",
+    body: `Good question, and not intentional in the way you might think. Sorry for the long delay.
+
+Several results from that report are already in the catalog - the ones where the report's own text shows a model settling a stated question. What keeps most OEIS-style conjecture work out is the inclusion test rather than significance: an entry needs a precisely stated open question that someone posed, whose answer is now a proved or disproved theorem. A machine-generated conjecture about a sequence, confirmed or extended, usually has nobody on the other side of it who asked. The significance axis then handles how much anyone cared; it is not a gate.
+
+The partial Erdős results are a different case and you may well be right that some are missing. Those do have a poser, and partial answers are trackable here - there are over a hundred entries with resolution Partial. If you have specific ones in mind, send them and they will be reviewed on their merits. Concrete pointers are more useful than a general sweep, because each one needs its source read.`,
+  },
+  {
+    ids: ["490d981a"],
+    who: "theabbie",
+    body: `Thank you, and apologies for the delay - this sat far longer than it should have.
+
+Verification here is set by hand, and what it asserts is narrow: that the account is the person it says it is. The evidence that settles it is a two-way link. A page you control that points at your VibeMathed profile or at an entry you submitted is the strongest kind, because it can be checked from both ends by anyone. An institutional email address, or a GitHub or arXiv profile carrying the same identity, also works.
+
+A LinkedIn profile alone is the one case that is hard to close from the outside: its contact details are not public, so "the email there matches this account" is something I cannot see. Add a line to your GitHub profile README or any personal page mentioning this account, or write from an address that is publicly tied to you, and it is done immediately.
+
+Nothing about this is a judgement on the account. It is only that the badge claims something specific, so it needs something specific behind it.`,
+  },
+  {
+    ids: ["d2b0d656"],
+    who: "shemshallah",
+    body: `Yes. Sorry for the slow answer.
+
+Verified profiles exist and are set by hand. Send something that ties this account to a public identity and it gets checked: a page you control that links back to your profile here or to an entry you submitted, an institutional email address, or a GitHub or arXiv profile under the same name. A two-way link is the strongest, because anyone can check it from either end.
+
+The badge asserts only identity. It is separate from the self-declared role on your profile, which is not checked, and it carries no special permissions.`,
+  },
+  {
+    ids: ["be31aac9"],
+    who: "Roy van Rijn",
+    body: `Thank you for the links, and sorry for the delay in coming back to you.
+
+One thing would close this immediately: a mention of this account on a page you control. A line on royvanrijn.com or in your GitHub profile README pointing at your VibeMathed profile makes the link checkable from both ends, which is what the badge is supposed to stand on. The three links you sent establish that Roy van Rijn exists and is who he says he is - what they cannot show from the outside is that this account is you, since the addresses on those pages are not public.
+
+If that is more trouble than it is worth, writing from an address that is publicly tied to you does the same job.`,
+  },
+  {
+    ids: ["4ead9963"],
+    who: "sjbevins",
+    body: `Thank you, and sorry for the slow reply - this one has been sitting since 1 September.
+
+Your profile is already verified, and carries the moderator role as well, so nothing is outstanding on that side.
+
+On the paper: it is a good fit, and a second AI-driven manuscript is very welcome. The thing that makes a submission easy to review is the disclosure - what the model actually did, named, with the human role beside it. The entries that go in fastest are the ones whose paper says plainly which step came from where. If the new manuscript has a disclosure section, say so in the submission and point at it.`,
+  },
+  {
+    ids: ["59ddce0e", "b447d934"],
+    who: "Saul Schleimer",
+    body: `Two answers, and apologies that they took eleven days.
+
+On verification: already done - your profile carries the badge. And you are right that Wikipedia is not the test. This site does count Wikipedia language editions, but for PROBLEMS, as a rough measure of how widely known a question was before it was solved. It has nothing to do with people, and it would be a poor measure of a mathematician even if it were meant as one.
+
+On the mysterious sentence: fair hit, and it is being reconsidered. "The record" means this catalog - the list of mathematical problems first solved with AI in the loop, with what was actually claimed, who checked it, and how far the checking went. The phrase was meant to say that the form reaches curators rather than a support desk, and instead it reads like a secret society. Something plainer would serve better.
+
+If you ever want to argue with a verification tier or a significance score, that is exactly the kind of mail worth getting. Several entries have been corrected that way.`,
+  },
+  {
+    ids: ["012e113e"],
+    who: "Matthew Protti",
+    body: `Both questions answered, and sorry for the delay - this crossed with the frontier work.
+
+The C11 frontier is live: vibemathed.com/frontier/shannon-capacity-c11. Six steps, from the published odd-cycles record through the BPZ updated certificate as the baseline, then your R3, R5, R6 and R10, with R10 as the headline at 5.295526013632343 in dimension 213. The two pending C11 submissions are one entry, linked from the frontier rather than duplicated. Your report on the comparison wording was applied on 12 September: both places now read "by exact integer comparisons, using cross-powers when dimensions differ", which is the honest description given the staircase mixes dimensions 207 and 213.
+
+On R7, your own note gives the answer and I agree with it. The inclusion test here is a precisely stated open question whose answer is now a theorem, and you say you have not identified one behind R7. A general compiler theorem for your own method does not have a poser on the other side of it. So it belongs as supporting material on the frontier rather than as its own entry - which is not a downgrade: a proved general theorem behind the avoidance-profile method makes every numbered step easier to trust, and that is worth more to a reader than another row.
+
+Send the release link and I will attach it to the frontier as methods.`,
+  },
+  {
+    ids: ["e3e6154a"],
+    who: "BraveEgret318 (Ryan Simonelli)",
+    body: `Done - your profile is verified, and thank you for making it easy to check.
+
+The evidence that settled it is the two-way link: your page at ryansimonelli.com/autonomous-philosophy.html links to the signed-depth-relevance-of-subdl entry, and that entry was submitted by this account. That can be checked from both ends by anyone, which is exactly what the badge is supposed to rest on. The verification note on your profile records that.
+
+Separately, your subDMQ submission was published today. It went in as AI-discovered on the paper's author line, significance 10, with the verification tier moved from Expert-verified to Unreviewed for the same reason as the subDL entry - the decision message on the entry sets out why at length, and the short version is that Ripley's confirmation currently lives in a footnote reporting a private exchange rather than in anything a reader can follow to its source. A public line from Ripley would lift it.
+
+More results in this area are genuinely welcome. Paraconsistent foundations is a corner where a model settling something has consequences for a live research programme, which is rarer than it sounds.`,
+  },
+];
+
+const EMAILS: Email[] = [
+  {
+    id: "ca5e9b2b",
+    who: "Olangu",
+    to: "olangu@impressions.se",
+    subject: "VibeMathed: both of your requests are done",
+    body: `Thank you for this, and I am sorry it took so long to answer - both things you asked for have in fact happened.
+
+The Ramachandra-Natarajan entry has been updated. It now reads Lean-checked, statement unaudited, which is the tier you proposed and the right one by our own rules, and your repository is linked from the entry. Its verification note records a curator source audit of all 579 lines: no sorry, admit, native_decide, unsafe declaration, user-declared axiom, implemented_by or partial def anywhere, with the finite checks going through kernel decide. So someone did read it, and it holds up.
+
+On sign-in: GitHub is now a second option alongside Google, and it links to an existing account with the same verified email rather than creating a duplicate. You can submit updates yourself from here on. Your point stood on its own merits - requiring a Google account excludes people for reasons that have nothing to do with mathematics.
+
+On an independent human reviewer for the paper-to-Lean correspondence: nothing to offer yet beyond the audit above, which checked the artifact rather than the correspondence to the paper. If someone with the relevant background reads it, the tier moves to Lean-verified. Saying plainly on the repository that you are looking for exactly that is the most likely way to find them.
+
+- Rasmus, VibeMathed`,
+  },
+  {
+    id: "d1e43b35",
+    who: "Wang Yuteng",
+    to: "wangyuteng202110@163.com",
+    subject: "VibeMathed: an AI-inspired category",
+    body: `Thank you for this, and apologies for the long delay.
+
+The category you describe is real and the site does not capture it: a human proof whose method was borrowed from an earlier AI discovery is genuinely a different thing from a proof with no AI anywhere near it, and today both look identical here, which is to say both are simply absent.
+
+The reason it has not been added is that the tier would be very hard to apply honestly. The existing AI-contribution tiers all rest on a disclosure in the paper - what the model did, in the authors' own words - and are set at face value from it. "The method came from an AI discovery" is usually nobody's claim: the later authors may not say it, may not know it, and if they do say it the strength of the debt is a matter of judgement rather than record. A tier that can only be assigned by a curator's inference is one that will be argued about forever and will not mean the same thing twice.
+
+What can be done without that problem is to say it in prose. An entry can record in its result note that the method descends from a specific earlier AI result and link it, and entries can be related to each other explicitly. That carries the information you want without asserting a tier nobody stated.
+
+If you have a specific pair in mind - an AI result and a later human proof that visibly borrows from it - send them. A concrete example is the thing most likely to change the decision, and it would be a good test of whether the link can be stated without guessing.
+
+- Rasmus, VibeMathed`,
+  },
+  {
+    id: "c0b88244",
+    who: "Alexandre Sedoglavic",
+    to: "Alexandre.Sedoglavic@univ-lille.fr",
+    subject: "VibeMathed: massive open problems and scope",
+    body: `Thank you, and apologies for the slow reply.
+
+The honest answer is that they are in scope by the letter of the rule and unmanageable by its practice, and the site has not resolved that.
+
+The inclusion test is a precisely stated open question whose answer is now a proved or disproved theorem. A single member of a large family of problems passes that test as cleanly as a famous conjecture does; the significance axis is what separates them, and a machine-generated or bulk-enumerated question sits near the bottom of it. So nothing about scale excludes them in principle.
+
+What scale breaks is review. Every entry here is reviewed by hand against its source before publishing, which is what the record is actually for. A family of results arriving together does not fit through that, and publishing them unreviewed would make the catalog larger and worth less.
+
+The shape of an answer probably looks like the Frontiers the site already has for quantities that improve in steps: one page for the family, with the individual results as rows rather than as separate entries, reviewed as a body of work with its provenance stated once. That is a design decision rather than something already built, and your message is a good argument for making it.
+
+If you are working on such a family and want to talk about how it would be represented, I would rather design it around a real case than in the abstract.
+
+- Rasmus, VibeMathed`,
+  },
+  {
+    id: "733c88d4",
+    who: "lenaxe3855",
+    to: "lenaxe3855@ittiv.com",
+    subject: "VibeMathed: the 254-year-old problem tip",
+    body: `Thank you for the tip, and sorry for the delay.
+
+A Stack Exchange answer is a lead rather than a source. Every entry here has to cite a primary record anyone can open and check - a paper, a preprint, a repository with the artifact in it - and a forum post is a pointer to one at best. The "254 years" framing also needs checking on its own: the age of a problem is a fact this site records, and it is wrong surprisingly often.
+
+If you can point at what sits behind the post - who made the claim, where the argument is written down, and what the model actually did - it can be assessed properly. The submission form at vibemathed.com/submit is the fastest route, and anyone can use it.
+
+- Rasmus, VibeMathed`,
+  },
+  {
+    id: "2bd8b152",
+    who: "Tracy McSheery",
+    to: "tracymcsheery@gmail.com",
+    subject: "VibeMathed: thanks",
+    body: `Thank you for this, and sorry for the slow reply.
+
+Your observation is the interesting part, more than the notes themselves: that the models would rather rewrite a hundred-year-old paper than try something new. That matches what the catalog shows. A great deal of what arrives is a re-proof of something already known, and the entries that survive review are the ones where a model settled a question nobody had answered - a much smaller pile.
+
+Nothing to action here, and nothing needed from you. Thanks for taking the time to write.
+
+- Rasmus, VibeMathed`,
+  },
+];
+
+const NOTES: Note[] = [
+  {
+    id: "ee233b65",
+    who: "anonymous - Yau-Tian-Donaldson hold challenge",
+    note: "The strongest message in this queue and unanswerable: anonymous with no reply address. Argues the extraordinary-claims hold on yau-tian-donaldson-conjecture-csck (arXiv:2608.19301) should lift, because the paper thanks Bin Dong, Guoxiong Gao, Chi Li, Gang Tian and Kewei Zhang 'for their enormous efforts in assisting with the verification of the paper' - three are Kahler geometers, none is an author, and Kewei Zhang made an explanatory video. That is a real argument: the rule asks for a named expert with no stake to have gone through the argument, and an acknowledgement of enormous efforts assisting with verification is closer to meeting it than anything else in the queue. It is not conclusive either, since thanks for assistance is not the same as a statement that the proof is correct. Still held as of 12 Sep 2026; this needs a curator decision, not a reply. The sender's two further claims are weaker and are not adopted: that models can now self-check well enough to retire the requirement, and that the S2xS3 curvature entry should move with it - that entry has no comparable acknowledgement.",
+  },
+  {
+    id: "1b2d851a",
+    who: "anonymous - overstatement criticism",
+    note: "Anonymous, no reply address. Says the headline framing, naming 'Combined years open before AI closed them', overstates AI's responsibility and borders on propaganda, while granting that the entries themselves are more nuanced. The criticism lands. A sum of ages across unrelated problems is a number with no meaning - it grows fastest by adding old problems, not by adding hard ones - and it is the most quotable thing on the site, which is exactly the combination that misleads. Recorded here as a change worth making rather than a message to answer: either drop the tile or give it a denominator that means something.",
+  },
+  {
+    id: "ff80dbe6",
+    who: "anonymous - radial coverage fingerprint",
+    note: "Anonymous, no reply address. Proposes a radial chart of coverage across mathematical fields for /stats, to show how spiky AI's progress currently is, with a mock-up at files.catbox.moe/07ocxx.png and the title 'The shape of AI mathematics'. The data already exists: fieldGroup is on every entry and the stats page already groups by it. Kept as a design note. Worth saying that the honest version of this chart would need care - a radial plot makes an uneven distribution look like a deliberate shape, and the unevenness here is mostly about which communities post preprints with disclosures.",
+  },
+];
+
+/// The one verification the public record settles from here. The other two
+/// requests hinge on an account email this script cannot compare to a
+/// LinkedIn or personal page; the dry run prints those emails so the curator
+/// can make the call directly.
+const VERIFY: { id: string; who: string; note: string }[] = [
+  {
+    id: "e3e6154a",
+    who: "BraveEgret318 (Ryan Simonelli)",
+    note: "Ryan Simonelli. Two-way link checked 12 September 2026: ryansimonelli.com/autonomous-philosophy.html links to vibemathed.com/problem/signed-depth-relevance-of-subdl, and that entry was submitted by this account.",
+  },
+];
+
+const PENDING_VERIFY: { id: string; who: string }[] = [
+  { id: "490d981a", who: "theabbie" },
+  { id: "be31aac9", who: "Roy van Rijn" },
+];
+
+function lint(): number {
+  let bad = 0;
+  const seen = new Set<string>();
+  for (const r of REPLIES) {
+    for (const id of r.ids) {
+      if (seen.has(id)) { console.log(`DUPLICATE id ${id}`); bad++; }
+      seen.add(id);
+    }
+    const n = r.body.length;
+    console.log(`REPLY  ${r.who.padEnd(26)} ${r.ids.join(",").padEnd(20)} ${n}/${MESSAGE_MAX}${n > MESSAGE_MAX ? "  OVER" : ""}`);
+    if (n > MESSAGE_MAX) bad++;
+  }
+  for (const e of EMAILS) {
+    if (seen.has(e.id)) { console.log(`DUPLICATE id ${e.id}`); bad++; }
+    seen.add(e.id);
+    console.log(`EMAIL  ${e.who.padEnd(26)} ${e.id.padEnd(20)} ${e.body.length} chars -> ${e.to}`);
+  }
+  for (const nt of NOTES) {
+    if (seen.has(nt.id)) { console.log(`DUPLICATE id ${nt.id}`); bad++; }
+    seen.add(nt.id);
+    console.log(`NOTE   ${nt.who.slice(0, 26).padEnd(26)} ${nt.id.padEnd(20)} ${nt.note.length} chars`);
+  }
+  console.log(`\n${seen.size} messages covered (expected 18)`);
+  if (seen.size !== 18) { console.log("COUNT MISMATCH"); bad++; }
+  return bad;
+}
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+/// Resolve an 8-character id prefix to the one open SiteMessage it names.
+async function resolve(
+  prefix: string,
+): Promise<{ id: string; topic: string; userId: string | null }> {
+  const rows = await prisma.$queryRawUnsafe<
+    { id: string; topic: string; userId: string | null }[]
+  >(
+    `SELECT id, topic, "userId" FROM "SiteMessage" WHERE id::text LIKE $1 || '%' AND status = 'open'`,
+    prefix,
+  );
+  if (rows.length !== 1)
+    throw new Error(`${prefix}: matched ${rows.length} open messages, expected 1`);
+  return rows[0];
+}
+
+/// The account behind a SiteMessage, by its foreign key.
+async function userFor(prefix: string) {
+  const row = await resolve(prefix);
+  if (!row.userId) throw new Error(`${prefix} has no userId`);
+  const u = await prisma.user.findUnique({
+    where: { id: row.userId },
+    select: { id: true, email: true, pseudonym: true, verified: true },
+  });
+  if (!u) throw new Error(`${prefix}: userId ${row.userId} has no account`);
+  return u;
+}
+
+async function main() {
+  const localBad = lint();
+  if (LINT) {
+    console.log(localBad ? `\n${localBad} local problem(s)` : "\nlocal checks ok");
+    process.exitCode = localBad ? 1 : 0;
+    return;
+  }
+  if (localBad) throw new Error(`${localBad} local problem(s) - nothing written`);
+
+  const db = await connectWithRetry();
+  console.log(`\ndatabase: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`);
+
+  const curator = await prisma.user.findFirst({
+    where: { pseudonym: "Rasmus Lindahl" },
+    select: { id: true, pseudonym: true },
+  });
+
+  // Every id must resolve to exactly one OPEN row, and every recipient must
+  // exist, before anything is written.
+  const ids = new Map<string, string>();
+  const recipient = new Map<string, string>();
+  for (const r of REPLIES) {
+    let uid: string | null = null;
+    for (const p of r.ids) {
+      const row = await resolve(p);
+      ids.set(p, row.id);
+      if (!row.userId) throw new Error(`${p} (${r.who}) has no userId - cannot reply in-app`);
+      if (uid && uid !== row.userId)
+        throw new Error(`${r.who}: ids ${r.ids.join(",")} belong to different accounts`);
+      uid = row.userId;
+    }
+    const u = await prisma.user.findUnique({
+      where: { id: uid! },
+      select: { id: true, email: true, pseudonym: true, verified: true },
+    });
+    if (!u) throw new Error(`${r.who}: userId ${uid} has no account`);
+    recipient.set(r.who, u.id);
+    console.log(
+      `REPLY  ${(u.pseudonym ?? r.who).padEnd(20)} ${r.ids.join(",")}  -> ${u.email ?? "(no email)"}${u.verified ? "  [verified]" : ""}`,
+    );
+  }
+  for (const e of EMAILS) ids.set(e.id, (await resolve(e.id)).id);
+  for (const nt of NOTES) ids.set(nt.id, (await resolve(nt.id)).id);
+  console.log(`\nall ${ids.size} ids resolve to open rows`);
+
+  console.log("\nverification:");
+  const toVerify = new Map<string, { id: string; note: string }>();
+  for (const v of VERIFY) {
+    const u = await userFor(v.id);
+    toVerify.set(u.pseudonym ?? v.who, { id: u.id, note: v.note });
+    console.log(
+      `  SET ${(u.pseudonym ?? v.who).padEnd(18)} verified ${u.verified} -> true   email ${u.email ?? "-"}`,
+    );
+  }
+  for (const p of PENDING_VERIFY) {
+    const u = await userFor(p.id);
+    console.log(
+      `  (not set) ${(u.pseudonym ?? p.who).padEnd(16)} verified ${u.verified}   account email: ${u.email ?? "-"}`,
+    );
+  }
+  console.log("  ^ compare those two against the identity each person claimed;");
+  console.log("    this script does not set them.");
+
+  console.log("\n" + "=".repeat(70));
+  console.log("EMAIL DRAFTS - the site cannot send mail, so send these by hand");
+  console.log("=".repeat(70));
+  for (const e of EMAILS) {
+    console.log(`\nTo: ${e.to}\nSubject: ${e.subject}\n\n${e.body}\n` + "-".repeat(70));
+  }
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to send");
+    return;
+  }
+  if (!curator) throw new Error("curator not found on this database");
+
+  for (const r of REPLIES) {
+    const uid = recipient.get(r.who);
+    if (!uid) throw new Error(`no recipient resolved for ${r.who}`);
+    await prisma.directMessage.create({
+      data: {
+        userId: uid,
+        senderId: curator.id,
+        senderName: curator.pseudonym,
+        kind: "note",
+        body: r.body.slice(0, MESSAGE_MAX),
+      },
+    });
+    for (const p of r.ids) {
+      await prisma.siteMessage.update({
+        where: { id: ids.get(p)! },
+        data: { status: "handled", handledAt: new Date() },
+      });
+    }
+    console.log(`replied: ${r.who} (${r.ids.join(",")})`);
+  }
+
+  for (const e of EMAILS) {
+    await prisma.siteMessage.update({
+      where: { id: ids.get(e.id)! },
+      data: { status: "handled", handledAt: new Date() },
+    });
+    console.log(`handled (email drafted): ${e.id} ${e.who}`);
+  }
+
+  for (const nt of NOTES) {
+    await prisma.siteMessage.update({
+      where: { id: ids.get(nt.id)! },
+      data: { status: "handled", handledAt: new Date() },
+    });
+    console.log(`handled (unreachable): ${nt.id} ${nt.who}`);
+  }
+
+  // Resolved BEFORE the loop above marked these rows handled. userFor() only
+  // matches OPEN rows, so re-resolving here finds nothing: the first
+  // production run sent all nine replies, handled all eighteen rows, and then
+  // died on "e3e6154a: matched 0 open messages". A write ordered after the
+  // write that invalidates its own lookup.
+  for (const [who, u] of toVerify) {
+    await prisma.user.update({
+      where: { id: u.id },
+      data: { verified: true, verifiedNote: u.note },
+    });
+    console.log(`verified: ${who}`);
+  }
+
+  console.log("\nAPPLIED. The contact queue should now be empty.");
+  console.log("Five emails above still need sending by hand.");
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/dump-queue.ts
+++ b/scripts/dump-queue.ts
@@ -1,0 +1,101 @@
+// Read-only: everything waiting on a curator, in one pass.
+//
+// dump-pending.ts covers submissions only, so a report or a contact message
+// could sit unseen while the submission queue looked empty. There are three
+// surfaces that can be waiting and they are easy to forget individually:
+//
+//   Problem.status = "pending"        reader submissions
+//   ProblemReport.status = "open"     "report a problem" on an entry or frontier
+//   SiteMessage.status = "open"       the contact form, including anonymous
+//
+// Submissions print in full because reviewing one needs every field. Reports
+// and messages print with the entry they point at, since a report body alone
+// ("the date is wrong") is not actionable without knowing which date.
+//
+// Reads only. Kept general rather than dated: this is the command to run
+// before any review session.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+
+const prisma = guardedPrisma();
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+function rule(title: string) {
+  console.log(`\n${"=".repeat(72)}\n${title}\n${"=".repeat(72)}`);
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(`database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}`);
+
+  const pending = await prisma.problem.findMany({
+    where: { status: "pending" },
+    include: { links: true },
+    orderBy: { createdAt: "asc" },
+  });
+  rule(`PENDING SUBMISSIONS: ${pending.length}`);
+  for (const p of pending) {
+    console.log(JSON.stringify(p, null, 2));
+    console.log("-".repeat(72));
+  }
+
+  const reports = await prisma.problemReport.findMany({
+    where: { status: "open" },
+    orderBy: { createdAt: "asc" },
+    include: {
+      problem: {
+        select: {
+          slug: true,
+          name: true,
+          status: true,
+          sourceUrl: true,
+          yearPosed: true,
+          posedBy: true,
+          solveDate: true,
+          verification: true,
+          resolution: true,
+          significance: true,
+        },
+      },
+      frontier: { select: { slug: true, name: true } },
+    },
+  });
+  rule(`OPEN REPORTS: ${reports.length}`);
+  for (const r of reports) {
+    console.log(JSON.stringify(r, null, 2));
+    console.log("-".repeat(72));
+  }
+
+  const messages = await prisma.siteMessage.findMany({
+    where: { status: "open" },
+    orderBy: { createdAt: "asc" },
+  });
+  rule(`OPEN CONTACT MESSAGES: ${messages.length}`);
+  for (const m of messages) {
+    console.log(JSON.stringify(m, null, 2));
+    console.log("-".repeat(72));
+  }
+
+  rule("TOTALS");
+  console.log(
+    `submissions ${pending.length}   reports ${reports.length}   messages ${messages.length}`,
+  );
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/fix-c11-frontier-wording-2026-09-12.ts
+++ b/scripts/fix-c11-frontier-wording-2026-09-12.ts
@@ -1,0 +1,167 @@
+// Handles the open report on the C11 frontier from Matthew Protti
+// (10 September 2026, report 8eecc7da).
+//
+// The request, verbatim from the report: replace "by exact integer powers at
+// matched dimension" in the 10 August 2026 BPZ row and in the closing
+// source/provenance paragraph with "by exact integer comparisons, using
+// cross-powers when dimensions differ". His reason: the staircase mixes
+// dimension 207 (BPZ, R3) and dimension 213 (R5, R6, R9, R10), and comparing
+// N_a^(1/d_a) against N_b^(1/d_b) across dimensions is done by the exact
+// integer comparison N_a^(d_b) versus N_b^(d_a). "Matched dimension" was
+// therefore wrong for the rows that matter; the correction changes no bound
+// and claims no new audit.
+//
+// The mathematics of the request is right - for positive bases and
+// dimensions, N_a^(1/d_a) < N_b^(1/d_b) iff N_a^(d_b) < N_b^(d_a) - and the
+// phrase occurs exactly twice on the live page, in the two places he names:
+// the `note` of the FrontierRow dated 2026-08-10 and the frontier's
+// `historyNote`. Both are edited; nothing else on the frontier is touched.
+//
+// Frontier and FrontierRow have no form and so no validator to mirror - only
+// the column widths (note 400, historyNote 600), which is how the C11
+// frontier hit P2000 when it was created. The replacement is 21 characters
+// longer than the original, so both lengths are checked here before any
+// write, and the script refuses if either would overflow. That is the whole
+// point of doing the length arithmetic in a dry run rather than finding out
+// from the database.
+//
+// The report is then marked handled, and the reporter gets a message saying
+// what was changed. He is the same contributor who built the C11 entry and
+// the releases the frontier transcribes, so the reply is short.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+import { charLength, canonical } from "../src/lib/char-length";
+import { MESSAGE_MAX } from "../src/lib/messages";
+
+const prisma = guardedPrisma();
+const APPLY = process.argv.includes("--apply");
+
+const FRONTIER = "shannon-capacity-c11";
+const ROW_DATE = "2026-08-10";
+const REPORT_ID = "8eecc7da-b698-40ce-9b66-a18473c3efcd";
+const OLD = "by exact integer powers at matched dimension";
+const NEW = "by exact integer comparisons, using cross-powers when dimensions differ";
+const NOTE_MAX = 400;
+const HISTORY_MAX = 600;
+
+const REPLY =
+  "Done, both places: the 10 August 2026 row note and the closing provenance paragraph now read \"by exact integer comparisons, using cross-powers when dimensions differ\". Your reasoning is right - the staircase mixes dimensions 207 and 213, and the honest description of how N_a^(1/d_a) is compared with N_b^(1/d_b) is the exact integer comparison N_a^d_b against N_b^d_a - and the earlier wording was wrong for exactly the rows that matter. No bound or attribution was changed. The frontier page can take up to an hour to show it, or until the next deploy. Thanks for reporting it precisely enough that the fix was a single phrase.";
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(`database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`);
+
+  const frontier = await prisma.frontier.findUnique({
+    where: { slug: FRONTIER },
+    select: {
+      id: true,
+      name: true,
+      historyNote: true,
+      rows: { where: { date: ROW_DATE }, select: { id: true, note: true, attribution: true } },
+    },
+  });
+  if (!frontier) throw new Error(`frontier not found on ${db}: ${FRONTIER}`);
+  const [row, ...more] = frontier.rows;
+  if (!row) throw new Error(`no row dated ${ROW_DATE}`);
+  if (more.length) throw new Error(`${more.length + 1} rows dated ${ROW_DATE}; expected one`);
+
+  const report = await prisma.problemReport.findUnique({
+    where: { id: REPORT_ID },
+    select: { id: true, status: true, userId: true, userName: true, frontierId: true },
+  });
+  if (!report) throw new Error(`report not found: ${REPORT_ID}`);
+  if (report.status !== "open") throw new Error(`report is ${report.status}, not open`);
+  if (report.frontierId !== frontier.id) throw new Error("report is not about this frontier");
+
+  console.log(`frontier : ${frontier.name}`);
+  console.log(`row      : ${ROW_DATE}  ${row.attribution}`);
+  console.log(`report   : ${report.status}, from ${report.userName ?? "(anonymous)"}\n`);
+
+  let bad = 0;
+  const plan: { what: string; before: string | null; after: string; max: number }[] = [
+    { what: "row.note", before: row.note, after: (row.note ?? "").replace(OLD, NEW), max: NOTE_MAX },
+    {
+      what: "frontier.historyNote",
+      before: frontier.historyNote,
+      // The wording fix alone lands at 608/600, which the dry run refused.
+      // "the repository README" -> "the README" recovers 15 characters and
+      // loses nothing: the sentence already says it is a repository table.
+      after: (frontier.historyNote ?? "")
+        .replace(OLD, NEW)
+        .replace("in the repository README at v0.5.0", "in the README at v0.5.0"),
+      max: HISTORY_MAX,
+    },
+  ];
+  for (const p of plan) {
+    const hits = (p.before ?? "").split(OLD).length - 1;
+    const n = charLength(canonical(p.after));
+    console.log(`${p.what}: ${hits} occurrence(s); after ${n}/${p.max}${n > p.max ? "  OVER" : ""}`);
+    if (hits !== 1) {
+      console.log(`  expected exactly one occurrence of the phrase - refusing`);
+      bad++;
+    }
+    if (n > p.max) bad++;
+    console.log(`  before: ${p.before}`);
+    console.log(`  after : ${p.after}\n`);
+  }
+  const rlen = charLength(canonical(REPLY));
+  console.log(`reply: ${rlen}/${MESSAGE_MAX}${rlen > MESSAGE_MAX ? "  OVER" : ""}`);
+  if (rlen > MESSAGE_MAX) bad++;
+  if (!report.userId) console.log("NOTE: anonymous report, no reply can be sent");
+  if (bad) throw new Error(`${bad} problem(s) - nothing written`);
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+
+  const curator = await prisma.user.findFirst({
+    where: { pseudonym: "Rasmus Lindahl" },
+    select: { id: true, pseudonym: true },
+  });
+  if (!curator) throw new Error("curator not found on this database");
+
+  await prisma.frontierRow.update({ where: { id: row.id }, data: { note: plan[0].after } });
+  await prisma.frontier.update({
+    where: { id: frontier.id },
+    data: { historyNote: plan[1].after },
+  });
+  await prisma.problemReport.update({
+    where: { id: report.id },
+    data: { status: "handled", handledAt: new Date() },
+  });
+  if (report.userId) {
+    await prisma.directMessage.create({
+      data: {
+        userId: report.userId,
+        senderId: curator.id,
+        senderName: curator.pseudonym,
+        kind: "report",
+        body: REPLY,
+      },
+    });
+  }
+  console.log("\nAPPLIED. The frontier page lags by up to an hour, or until a deploy.");
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/fix-euler-age-2026-09-10.ts
+++ b/scripts/fix-euler-age-2026-09-10.ts
@@ -1,0 +1,215 @@
+// The Euler entry dated a classical problem to a document that excludes it.
+//
+// It went in with yearPosed 2000 and posedBy "Classical; the breakdown
+// question is recorded in Fefferman's official Clay problem description", so
+// the site reported it as 26 years old - younger than most of the catalog -
+// on the strength of a document whose own text says the Euler equation "is
+// not on the Clay Institute's list of prize problems". Recording that a
+// problem is open is not posing it, and the record chosen here does not even
+// claim it.
+//
+// The sources agree on where the question actually starts. Elgindi's Annals
+// paper, cited by this work as [10] and the nearest precedent for blowup in
+// 3D Euler, opens: "It has been known since work of Lichtenstein [43] and
+// Gunther [30] in the 1920's that the 3D incompressible Euler equation is
+// locally well-posed in the class of velocity fields with Holder continuous
+// gradient and suitable decay at infinity. It is shown here that these local
+// solutions can develop singularities in finite time." That is the gap: local
+// existence proved, global regularity left open. It opens with Lichtenstein
+// 1925 (Math. Z. 23, 89-154); Gunther 1927 confirms it.
+//
+// Elgindi also states the question in the exact form this entry asks it,
+// forcing included:
+//
+//   Question 1.1. Given a solution u in C-infinity(R^3 x [0,T)) ... and
+//   external force f in (C-infinity intersect L^2)(R^3 x [0,T]), is it
+//   possible that lim sup |grad u| = +infinity?
+//
+// and calls it "the well-known global regularity problem for the
+// incompressible Euler equation". So the smooth force is not a weaker
+// side-question invented later; it is how the problem is posed. He adds that
+// the C^{1,alpha} case he settles is "the context within which the classical
+// well-posedness theory of the Euler equation has been considered starting
+// with the works of Lichtenstein and Gunther".
+//
+// 1925, then, and 101 years rather than 26.
+//
+// The literature carries a second framing - Chen and Hou's PNAS paper dates
+// the problem to "Leonhard Euler introduced the equations in 1757" - but that
+// dates the equations, not the question. In 1757 there was no local existence
+// theory for it to leave a gap in. Taking it would be the same choice as
+// dating Navier-Stokes to Navier in 1822 rather than to Leray in 1934, and
+// this catalog dates that one from Leray.
+//
+// Sibling of scripts/fix-navier-stokes-age-2026-09-10.ts, and found the same
+// way: the two entries sit next to each other on the significance-vs-age
+// scatter, one at 92 years and this one at 26.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+import { checkStoredEntry } from "../src/lib/field-validation";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { charLength, canonical } from "../src/lib/char-length";
+import { ageAtSolve } from "../src/lib/problems";
+
+const prisma = guardedPrisma();
+const APPLY = process.argv.includes("--apply");
+const SPECS = [...EDITABLE_FIELDS, ...CURATOR_FIELDS];
+
+const SLUG = "euler-blowup-smooth-forcing";
+
+// ageNote is deliberately NOT touched, and the first draft of this script got
+// that wrong. It planned to write the dating rationale there, the way the
+// Navier-Stokes fix did - but Navier-Stokes had no ageNote to lose, and this
+// entry does: a curator-written note on the release ("Released 8 September
+// 2026, earlier than the authors intended... Buckmaster calls the Euler
+// writeup 'AI slop', apologises for its state, and attributes the early
+// release to outside pressure"). The dry run printed it, which is the whole
+// reason dry runs print the before value. Writing over it would have destroyed
+// the only record of that on the entry.
+//
+// posedBy carries the dating on its own, and it is the more prominent field:
+// it renders on the card and on the entry page, where ageNote renders on
+// neither - ageNote is only the asterisk on "Open Ny" in the card list
+// (ProblemCards.tsx). The full argument lives in this file's header and in the
+// Elgindi link added below.
+//
+// Worth a separate decision by the curator: that existing ageNote explains the
+// SOLVE date, so it is currently the footnote on the wrong number. Moving it
+// is a rewrite of curator prose, not a correction, so it is not done here.
+const EDITS = {
+  yearPosed: 1925,
+  posedBy:
+    "Leon Lichtenstein (1925) and Nikolai Gunther (1927), whose local existence left global regularity open; Elgindi states the smooth-force form as his Question 1.1",
+};
+
+// The entry asserts a posing it cannot cite: its only problem record is
+// Fefferman's Clay description, which is the source for the Clay caveat
+// rather than for the question. Elgindi's paper is where the question is
+// written down in the form this entry asks it.
+const NEW_LINK = {
+  label: "Elgindi, Annals 2021: Question 1.1, the problem in the form asked here",
+  url: "https://arxiv.org/abs/1904.04795",
+  kind: "problem-record",
+};
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(`database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`);
+
+  const [before] = await prisma.$queryRawUnsafe<
+    {
+      id: string;
+      yearPosed: number | null;
+      posedBy: string | null;
+      ageNote: string | null;
+      solveDate: string;
+      sourceUrl: string | null;
+    }[]
+  >(
+    `SELECT id, "yearPosed", "posedBy", "ageNote", "solveDate", "sourceUrl"
+       FROM "Problem" WHERE slug = $1`,
+    SLUG,
+  );
+  if (!before) throw new Error(`not found on ${db}: ${SLUG}`);
+
+  const links = await prisma.$queryRawUnsafe<
+    { label: string; url: string; kind: string; position: number }[]
+  >(
+    `SELECT label, url, kind, position FROM "ProblemLink"
+      WHERE "problemId" = $1 ORDER BY position`,
+    before.id,
+  );
+
+  const oldAge = ageAtSolve({
+    yearPosed: before.yearPosed,
+    solveDate: before.solveDate,
+  });
+  const newAge = ageAtSolve({
+    yearPosed: EDITS.yearPosed,
+    solveDate: before.solveDate,
+  });
+
+  console.log(`yearPosed : ${before.yearPosed} -> ${EDITS.yearPosed}`);
+  console.log(`age       : ${oldAge} years -> ${newAge} years`);
+  console.log(`\nposedBy before: ${before.posedBy}`);
+  console.log(`posedBy after : ${EDITS.posedBy}`);
+  console.log(`                (${charLength(canonical(EDITS.posedBy))}/200)`);
+  console.log(`\nageNote  : NOT TOUCHED, and it is not about the age. It reads:`);
+  console.log(`             ${before.ageNote ?? "(null)"}`);
+  console.log(`           That is the release story, and it is the footnote on`);
+  console.log(`           "Open Ny". Moving it is the curator's call, not this`);
+  console.log(`           script's.`);
+
+  console.log(`\nexisting links (${links.length}), source = ${before.sourceUrl}`);
+  for (const l of links) console.log(`  [${l.kind}] ${l.label}\n      ${l.url}`);
+  console.log(`\nadd link: [${NEW_LINK.kind}] ${NEW_LINK.label}`);
+  console.log(`      ${NEW_LINK.url}   (label ${NEW_LINK.label.length}/120)`);
+
+  // The same check the guarded client runs on write, so the dry run gives the
+  // answer the write would rather than promising success and failing later.
+  const merged = [...links, NEW_LINK];
+  const v = [
+    ...checkStoredEntry({ specs: SPECS, fields: EDITS }),
+    ...checkStoredEntry({
+      specs: SPECS,
+      links: merged,
+      sourceUrl: before.sourceUrl,
+    }),
+  ];
+  console.log(`\nfield check: ${v.length ? "FAILED" : "ok"}`);
+  for (const x of v) console.log(`  - ${x.field}: ${x.problem}`);
+  if (v.length) throw new Error("would be refused");
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+
+  await prisma.problem.update({
+    where: { slug: SLUG },
+    data: EDITS,
+    select: { id: true },
+  });
+  await prisma.problemLink.create({
+    data: {
+      problemId: before.id,
+      label: NEW_LINK.label,
+      url: NEW_LINK.url,
+      kind: NEW_LINK.kind,
+      position: links.length ? Math.max(...links.map((l) => l.position)) + 1 : 0,
+    },
+    select: { id: true },
+  });
+  // Not "the entry page is right immediately". That is what every earlier
+  // script printed and it is only true for a NEW entry, whose page has
+  // nothing cached yet. This is an edit: the entry page is behind
+  // cacheLife("hours") with cacheTag("problems", `problem-${slug}`)
+  // (src/lib/data.ts), and a direct database write calls no revalidateTag,
+  // because revalidateTag only exists inside a request. So every public
+  // surface lags, the entry page included.
+  console.log("\nAPPLIED. Every public surface lags by up to an hour: this is a");
+  console.log("write straight to the database, so nothing revalidates a tag.");
+  console.log("A deploy clears it, and so does saving the entry once in the UI.");
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/fix-navier-stokes-age-2026-09-10.ts
+++ b/scripts/fix-navier-stokes-age-2026-09-10.ts
@@ -1,0 +1,140 @@
+// The Navier-Stokes entry dated the problem to its prize, not its posing.
+//
+// It went in with yearPosed 2000 and posedBy "Charles L. Fefferman, Clay
+// Mathematics Institute", so the site reported the problem as 26 years old.
+// Every primary source dates it to Leray:
+//
+//   Fefferman's own Clay description cites [5] J. Leray, "Sur le mouvement
+//   d'un liquide visqueux emplissant l'espace", Acta Math. 63 (1934), and
+//   builds its whole weak-solution discussion from it: "Starting with Leray
+//   [5], important progress has been made".
+//
+//   OpenAI's paper, section 1: "In 1934, Leray constructed global
+//   finite-energy weak solutions of the three-dimensional equations
+//   satisfying an energy inequality. Whether solutions starting from smooth
+//   data remain smooth was left unresolved."
+//
+//   OpenAI's announcement: "In 1934, Jean Leray proved that solutions exist
+//   in a generalized sense, but whether they always remain smooth became a
+//   central unanswered question. In 2000, the Clay Mathematics Institute
+//   named [it] one of seven Millennium Prize Problems" - and separately,
+//   "unresolved for roughly 90 years".
+//
+// So 1934, and the true age at resolution is 92 years rather than 26. That
+// is not cosmetic: ageAtSolve is solveYear - yearPosed, and it places the
+// point on the significance-vs-age scatter. At 26 the entry sat in the
+// crowded left-hand band with results from the 2000s; at 92 it sits out
+// where problems of that vintage belong.
+//
+// The 2000 date is kept where it belongs - in posedBy and ageNote - because
+// the Clay statement is what fixed alternatives (C) and (D), the precise
+// propositions this result settles. It formalised the question; it did not
+// pose it.
+//
+// Noticed because the duplicate submission I declined had dated it 1934 and
+// I said so in the decline message, then did not apply it to the entry that
+// was kept.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+import { checkStoredEntry } from "../src/lib/field-validation";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { ageAtSolve } from "../src/lib/problems";
+
+const prisma = guardedPrisma();
+const APPLY = process.argv.includes("--apply");
+const SPECS = [...EDITABLE_FIELDS, ...CURATOR_FIELDS];
+
+const SLUG =
+  "navier-stokes-millennium-prize-problem-finite-time-breakdown-with-smooth-forcing";
+
+const EDITS = {
+  yearPosed: 1934,
+  posedBy:
+    "Jean Leray (1934), whose weak solutions left smoothness open; stated as Millennium alternatives (C) and (D) by Charles Fefferman for the Clay Mathematics Institute in 2000",
+  ageNote:
+    "Dated from Leray's 1934 paper, which constructed global weak solutions and left smoothness open, rather than from the 2000 Clay formulation. Fefferman's own problem description builds from Leray, and OpenAI's paper and announcement both date the question to 1934. The Clay statement fixed alternatives (C) and (D), the propositions this result settles; it did not pose the question.",
+};
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const [before] = await prisma.$queryRawUnsafe<
+    {
+      yearPosed: number | null;
+      posedBy: string | null;
+      ageNote: string | null;
+      solveDate: string;
+    }[]
+  >(
+    `SELECT "yearPosed", "posedBy", "ageNote", "solveDate" FROM "Problem" WHERE slug = $1`,
+    SLUG,
+  );
+  if (!before) throw new Error(`not found on ${db}: ${SLUG}`);
+
+  const oldAge = ageAtSolve({
+    yearPosed: before.yearPosed,
+    solveDate: before.solveDate,
+  });
+  const newAge = ageAtSolve({
+    yearPosed: EDITS.yearPosed,
+    solveDate: before.solveDate,
+  });
+
+  console.log(`yearPosed : ${before.yearPosed} -> ${EDITS.yearPosed}`);
+  console.log(`age        : ${oldAge} years -> ${newAge} years`);
+  console.log(`\nposedBy before: ${before.posedBy}`);
+  console.log(`posedBy after : ${EDITS.posedBy}`);
+  console.log(`\nageNote before: ${before.ageNote ?? "(null)"}`);
+  console.log(`ageNote after : ${EDITS.ageNote}`);
+
+  // The guarded client checks this again on write; running it here means the
+  // dry run reports the same answer the write would, rather than promising
+  // success and failing later.
+  const v = checkStoredEntry({ specs: SPECS, fields: EDITS });
+  console.log(`\nfield check: ${v.length ? "FAILED" : "ok"}`);
+  for (const x of v) console.log(`  - ${x.field}: ${x.problem}`);
+  if (v.length) throw new Error("would be refused");
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+
+  await prisma.problem.update({
+    where: { slug: SLUG },
+    data: EDITS,
+    select: { id: true },
+  });
+  // Not "the entry page is right immediately". That is only true for a NEW
+  // entry, whose page has nothing cached yet. This is an edit, and the entry
+  // page is behind cacheLife("hours") with cacheTag (src/lib/data.ts) that a
+  // direct database write never revalidates.
+  console.log("\nAPPLIED. Every public surface lags by up to an hour: this is a");
+  console.log("write straight to the database, so nothing revalidates a tag.");
+  console.log("A deploy clears it, and so does saving the entry once in the UI.");
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/lib/guarded-prisma.ts
+++ b/scripts/lib/guarded-prisma.ts
@@ -1,0 +1,207 @@
+// The Prisma client every curator script must use.
+//
+// Scripts used to construct a bare PrismaClient and write whatever they were
+// given. Nothing between them and the database ran the rules the edit form
+// enforces, so the catalog collected rows the form refuses - and an entry
+// holding one of those could not be saved by anyone afterwards. Twelve
+// published entries were in that state on 10 September 2026; one of them had
+// been created by a review script the day before.
+//
+// This wrapper puts the form's validator in the write path. Creating or
+// updating a Problem, or adding a ProblemLink, runs `checkStoredEntry` from
+// src/lib/field-validation.ts - the same module the server actions import -
+// against the MERGED result (stored data plus the change), and refuses to
+// write if anything would violate a rule. The refusal names the field and the
+// rule, which is more than the database's P2000 ever did.
+//
+// Raw SQL cannot be validated, so INSERT and UPDATE on the two guarded tables
+// are refused outright through this client; use the model API. SELECT and
+// DELETE stay open - a delete cannot create a violation, and scripts need to
+// read.
+//
+// A test (src/lib/scripts-use-guard.test.ts) fails the build if a script
+// under scripts/ constructs its own PrismaClient, so the guard is not a
+// convention a future script can forget.
+
+import { PrismaClient } from "@prisma/client";
+import { checkStoredEntry } from "../../src/lib/field-validation";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../../src/lib/editable";
+
+const SPECS = [...EDITABLE_FIELDS, ...CURATOR_FIELDS];
+
+export class WriteRefused extends Error {
+  constructor(what: string, violations: { field: string; problem: string }[]) {
+    super(
+      `${what} refused - it would leave the entry uneditable through the form:\n` +
+        violations.map((v) => `  - ${v.field}: ${v.problem}`).join("\n"),
+    );
+    this.name = "WriteRefused";
+  }
+}
+
+type LinkIn = { label: string; url: string };
+
+/// Nested link creates arrive in several shapes; normalise to a flat list.
+function linksFrom(data: Record<string, unknown> | undefined): LinkIn[] {
+  const nested = (data?.links as { create?: unknown } | undefined)?.create;
+  if (!nested) return [];
+  return (Array.isArray(nested) ? nested : [nested]) as LinkIn[];
+}
+
+/// Scalar fields only: the validator ignores keys it has no spec for, and
+/// Prisma relation payloads (links, relationsFrom...) are not scalars.
+function scalars(
+  data: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(data ?? {})) {
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+const RAW_WRITE = /\b(INSERT\s+INTO|UPDATE)\s+"?(Problem|ProblemLink)"?\b/i;
+
+export function guardedPrisma() {
+  const base = new PrismaClient();
+
+  const client = base.$extends({
+    query: {
+      problem: {
+        async create({ args, query }) {
+          const data = args.data as Record<string, unknown>;
+          const v = checkStoredEntry({
+            specs: SPECS,
+            fields: scalars(data),
+            links: linksFrom(data),
+            sourceUrl: (data.sourceUrl as string | undefined) ?? null,
+          });
+          if (v.length) throw new WriteRefused("problem.create", v);
+          return query(args);
+        },
+        async update({ args, query }) {
+          const data = args.data as Record<string, unknown>;
+          // Validate the merged result, not the fragment: a new link is only
+          // a duplicate relative to the links already there, and a changed
+          // sourceUrl is only a clash relative to the links it now sits over.
+          const cur = await base.problem.findUnique({
+            where: args.where,
+            select: {
+              sourceUrl: true,
+              links: { select: { label: true, url: true } },
+            },
+          });
+          const merged = [...(cur?.links ?? []), ...linksFrom(data)];
+          const v = checkStoredEntry({
+            specs: SPECS,
+            fields: scalars(data),
+            links: merged,
+            sourceUrl:
+              (data.sourceUrl as string | undefined) ?? cur?.sourceUrl ?? null,
+          });
+          if (v.length) throw new WriteRefused("problem.update", v);
+          return query(args);
+        },
+        async upsert({ args, query }) {
+          for (const [what, d] of [
+            ["upsert.create", args.create],
+            ["upsert.update", args.update],
+          ] as const) {
+            const data = d as Record<string, unknown>;
+            const v = checkStoredEntry({
+              specs: SPECS,
+              fields: scalars(data),
+              links: linksFrom(data),
+              sourceUrl: (data.sourceUrl as string | undefined) ?? null,
+            });
+            if (v.length) throw new WriteRefused(`problem.${what}`, v);
+          }
+          return query(args);
+        },
+      },
+      problemLink: {
+        async create({ args, query }) {
+          const d = args.data as {
+            label: string;
+            url: string;
+            problemId?: string;
+            problem?: { connect?: { id?: string } };
+          };
+          const problemId = d.problemId ?? d.problem?.connect?.id;
+          const cur = problemId
+            ? await base.problem.findUnique({
+                where: { id: problemId },
+                select: {
+                  sourceUrl: true,
+                  links: { select: { label: true, url: true } },
+                },
+              })
+            : null;
+          const v = checkStoredEntry({
+            specs: SPECS,
+            links: [...(cur?.links ?? []), { label: d.label, url: d.url }],
+            sourceUrl: cur?.sourceUrl ?? null,
+          });
+          if (v.length) throw new WriteRefused("problemLink.create", v);
+          return query(args);
+        },
+        async update({ args, query }) {
+          const d = args.data as { label?: string; url?: string };
+          const row = await base.problemLink.findUnique({
+            where: args.where,
+            select: {
+              id: true,
+              label: true,
+              url: true,
+              problem: {
+                select: {
+                  sourceUrl: true,
+                  links: { select: { id: true, label: true, url: true } },
+                },
+              },
+            },
+          });
+          if (row) {
+            const links = row.problem.links.map((l) =>
+              l.id === row.id
+                ? { label: d.label ?? l.label, url: d.url ?? l.url }
+                : { label: l.label, url: l.url },
+            );
+            const v = checkStoredEntry({
+              specs: SPECS,
+              links,
+              sourceUrl: row.problem.sourceUrl,
+            });
+            if (v.length) throw new WriteRefused("problemLink.update", v);
+          }
+          return query(args);
+        },
+      },
+    },
+  });
+
+  // Raw writes to the guarded tables cannot be checked, so they are refused.
+  const rawExec = base.$executeRawUnsafe.bind(base);
+  const guardedExec: typeof base.$executeRawUnsafe = (
+    sql: string,
+    ...params: unknown[]
+  ) => {
+    if (RAW_WRITE.test(sql)) {
+      throw new WriteRefused("raw SQL write to Problem/ProblemLink", [
+        {
+          field: "sql",
+          problem:
+            "use prisma.problem / prisma.problemLink so the form's rules run",
+        },
+      ]);
+    }
+    return rawExec(sql, ...params);
+  };
+  (client as unknown as { $executeRawUnsafe: unknown }).$executeRawUnsafe =
+    guardedExec;
+
+  return client;
+}
+
+export type GuardedPrisma = ReturnType<typeof guardedPrisma>;

--- a/scripts/prod.sh
+++ b/scripts/prod.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run a curator script against PRODUCTION.
+#
+#   bash scripts/prod.sh scripts/review-2026-09-12.ts
+#   bash scripts/prod.sh scripts/review-2026-09-12.ts --apply
+#
+# Exists because the one-line form - DATABASE_URL="$(sed ... )" npx tsx ... -
+# is long enough that the terminal wraps it when pasted, and the wrapped
+# second line then runs the .ts file as a shell script. The URL is read from
+# the production env file, which is gitignored; nothing secret lives here.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+URL="$(sed -nE 's/^DATABASE_URL="?([^"]+)"?$/\1/p' .env.production-backup-2026-09-04 | head -1)"
+if [ -z "$URL" ]; then
+  echo "no DATABASE_URL in .env.production-backup-2026-09-04" >&2
+  exit 1
+fi
+DATABASE_URL="$URL" exec npx tsx "$@"

--- a/scripts/review-2026-09-10.ts
+++ b/scripts/review-2026-09-10.ts
@@ -1,0 +1,402 @@
+// Review of the two submissions pending on 10 September 2026.
+// One approved with edits, one held.
+//
+// ---------------------------------------------------------------------------
+// XI NORMALITY - approved, tier kept, framing corrected.
+//
+// Claim: the value at 1/2 of Dibag's logarithm localized at the primes 2 and 3,
+//
+//     xi = sum over m = 2^a 3^c of 1/(m 2^m) = 0.68562264189340237754...
+//
+// is normal in base two. Summing the same terms over EVERY positive integer
+// instead of the 3-smooth ones gives log 2, which is what "localized" means
+// here and why the constant is not arbitrary.
+//
+// Checked rather than trusted, at the level the Lean tier requires:
+//
+//   1. Statement fidelity. Challenge.lean imports only
+//      Mathlib.Analysis.Real.OfDigits. It writes the constant out in full as
+//      the double sum and states normality directly - for every length l and
+//      every j < 2^l, the proportion of starting positions n < M whose shifted
+//      fractional part lands in [j/2^l, (j+1)/2^l) tends to 2^-l. There is no
+//      project-defined normality predicate and no project-defined constant in
+//      it, which is the place a faithful-looking statement could have been
+//      quietly weakened. Overlapping occurrences are counted, which is the
+//      strong reading.
+//   2. The bridge. Solution.lean derives exactly that statement from the
+//      development by unfolding definitions, and comparator.json compares
+//      XiComparator.normality with only propext, Classical.choice and
+//      Quot.sound permitted.
+//   3. Smuggled hypotheses. Statement takes no arguments beyond l, j and
+//      j < 2^l, so there is no slot for an unproven input passed as a theorem
+//      argument - the failure mode that demoted the Erdos-Borwein entry.
+//   4. Counted, not assumed: no sorry anywhere outside the deliberate
+//      placeholder in ComparatorChallenge.lean, no axiom declarations, no
+//      native_decide, no unsafe.
+//   5. Independent of the author's machine. Audit.lean pins the axiom lists
+//      with #guard_msgs, so a changed list is a build ERROR rather than an
+//      informational line, and GitHub Actions ran the whole pipeline twice on
+//      9 September from the pinned toolchain (Lean 4.34.0-rc2) and pinned
+//      mathlib commit and passed both times. That is more than most Lean
+//      submissions here can show.
+//
+// Not done: rebuilding it here. mathlib from source is not reproducible on
+// this machine, so "the kernel accepted this" rests on the CI record.
+//
+// THE ONE CORRECTION, and it is to the submitter's note rather than the paper.
+// The note says the real point is normality for a "natural" constant, "a
+// number not constructed with the purpose of being normal". The paper is more
+// careful and says the opposite of the strong reading: the one-prime values
+// "already belong to an established normal family", citing Stoneham 1973 and
+// Bailey-Crandall 2002 as an exact precedent, and it states that it has not
+// located an earlier published conjecture about xi. So the entry records what
+// this is - the mixed-prime extension of the Stoneham programme, where all the
+// indices 2^a 3^c contribute at once - rather than a first normality proof for
+// a natural constant. Real work, different claim.
+//
+// Significance 15, placed against named neighbours as the methodology asks:
+// below reciprocal-fermat-constant-is-nonnormal at 18 (a named constant with a
+// literature behind it), well below the-erdos-borwein-constant-is-2-dense at 25
+// (answers a 2002 question of Crandall), above the machine-generated band
+// because the target is recognisable inside a cited programme. Nobody had
+// posed this question, and that axis measures how much mathematics cared
+// before the solve.
+//
+// sourceUrl is repointed from the mutable main branch to commit 0696181, the
+// one reviewed and the one CI built, following the percolation precedent. The
+// repository is the entire evidentiary basis here - there is no arXiv posting -
+// so a branch that can move is not good enough.
+//
+// aiContribution stays ai-discovered, the submitter's own account of their own
+// project, but aiRole now says exactly what does and does not back it: the
+// repository credits describe "an AI-assisted mathematical project" and
+// attribute the submission documentation to Codex without separating model
+// from human, and the paper carries no author byline.
+//
+// ---------------------------------------------------------------------------
+// GROMOV-HAUSDORFF - held under the extraordinary-claims rule.
+//
+// Ishiki, arXiv 2609.09639: the Gromov-Hausdorff space M is homeomorphic to
+// separable infinite-dimensional Hilbert space. 87 pages, version 1, posted
+// 9 September, one day old at review.
+//
+// The submitter asked directly whether the site's independent-verification
+// requirement applies. It does. A complete topological classification of M is
+// a major result by any metric geometer's standard, and the methodology says
+// such a claim is not published at Unreviewed and not published as a Candidate
+// either, because a listing here puts the site's name beside a claim it has
+// not read. Nobody has read this one - here or anywhere, in a day.
+//
+// Nothing about the submission is wrong. Its verificationNote already says
+// author checking alone does not meet the bar; its note about Antonyan (2020)
+// recording the questions rather than establishing an earliest date is the
+// honest way to put it; the AI disclosure it summarises is verbatim accurate
+// against the paper ("Use of AI. OpenAI Codex, based on GPT-6, was used to
+// explore and develop the mathematical constructions and proofs... The author
+// has verified all mathematical arguments... and takes full responsibility").
+// The rule is about the size of the claim, not the credentials or the care of
+// whoever brings it, and it has already been applied to a Yau-Tian-Donaldson
+// disproof and a positive-curvature claim.
+//
+// One data defect fixed while holding: the row stores fieldGroup
+// "Geometry &amp; topology", HTML-escaped, where the allowed option is
+// "Geometry & topology". Left alone it is a choice-field violation that would
+// refuse the entry on any later edit - exactly the class of stale-value trap
+// the guarded client exists to stop. All 706 published entries are clean of
+// HTML entities, so this is new and the submission path is worth a look; the
+// server action does no escaping, so it arrived escaped.
+//
+// Everything else on the row is kept untouched so that, when the claim has
+// stood up, the entry can be published as it stands.
+//
+// ---------------------------------------------------------------------------
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+import { checkStoredEntry } from "../src/lib/field-validation";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { MESSAGE_MAX } from "../src/lib/messages";
+
+const prisma = guardedPrisma();
+const APPLY = process.argv.includes("--apply");
+// --lint: message lengths only, no database. Added after the production dry
+// run refused both messages as over the cap, which a local check would have
+// caught before the curator ran anything.
+const LINT = process.argv.includes("--lint");
+const SPECS = [...EDITABLE_FIELDS, ...CURATOR_FIELDS];
+const LINK_LABEL_MAX = 120;
+
+const SHA = "06961817c7f61181ed9a5c73badb8d908d6ccdcc";
+const REPO = "https://github.com/CaptainSude/xi-normality";
+
+interface Decision {
+  slug: string;
+  action: "approve" | "reject";
+  reason: string;
+  message: string;
+  edits?: Record<string, unknown>;
+  links?: { label: string; url: string; kind: string }[];
+  reviewNote?: string;
+}
+
+const DECISIONS: Decision[] = [
+  {
+    slug: "binary-normality-of-localized-logarithm-value",
+    action: "approve",
+    reason: "edited",
+    edits: {
+      name: "Binary normality of a localized logarithm value",
+      field: "Normal numbers and digit expansions",
+      statement:
+        "Let $\\xi=\\sum_{a,c\\ge 0}\\frac{1}{2^{a}3^{c}\\,2^{2^{a}3^{c}}}$, the value at $1/2$ of Dibag's logarithm localized at the primes $2$ and $3$; summing the same terms over every positive integer rather than only the $3$-smooth ones gives $\\log 2$. Is $\\xi$ normal in base two, that is, does every finite binary word of length $l$ occur in its binary expansion with limiting frequency $2^{-l}$, counting overlapping occurrences?",
+      resultNote:
+        "Yes. Every finite binary word occurs with its expected limiting frequency, overlapping occurrences counted. The one-prime members of this family were already known to be normal: $\\alpha_{b,p}=\\sum_{k\\ge1}p^{-k}b^{-p^{k}}$ is Stoneham's constant, proved normal under primitive-root hypotheses by Stoneham in 1973 and unconditionally for coprime parameters by Bailey and Crandall in 2002. The new content is the mixed-prime support, where all the indices $2^{a}3^{c}$ contribute at once and the argument turns on the largest power of three in the truncation denominator surviving addition. The paper states that it has not located an earlier published conjecture about $\\xi$, so this settles no previously posed question. The Lean development covers qualitative normality of this constant only; the paper's quantitative discrepancy bound and its extension to larger finite sets of primes are outside the formalisation.",
+      verificationNote:
+        "Checked here on 10 September 2026 by reading the repository at commit 0696181. Challenge.lean imports only Mathlib.Analysis.Real.OfDigits, writes the constant out in full as the double sum, and states normality directly: for every length $l$ and every $j<2^{l}$, the proportion of starting positions $n<M$ whose shifted fractional part lands in $[j/2^{l},(j+1)/2^{l})$ tends to $2^{-l}$. No project-defined normality predicate and no project-defined constant appears in it, which is where a faithful-looking statement could have been quietly weakened, and the statement takes no extra hypotheses that could carry an unproven input. Solution.lean derives that statement from the development, and comparator.json compares XiComparator.normality with only propext, Classical.choice and Quot.sound permitted. Audit.lean pins the axiom lists with #guard_msgs, so a changed list fails the build rather than printing a note. GitHub Actions built the project twice on 9 September from the pinned toolchain (Lean 4.34.0-rc2) and the pinned mathlib commit and passed, which puts the kernel check on a machine other than the author's. The build was not repeated here, and the repository's README records that no external statement audit has been made.",
+      aiRole:
+        "The submitter states that ChatGPT-6 Astra chose the problem, proved it and produced the Lean formalisation. The repository's own credits are less specific: they describe an AI-assisted mathematical project, attribute the submission documentation and interface to OpenAI Codex, and do not separate what a model did from what a person did. The paper carries no author byline. Nothing found in review corroborates the autonomy claim beyond the submitter's word, and nothing contradicts it; it is recorded as their account rather than as an established fact.",
+      significance: 15,
+      significanceNote:
+        "Normality of a constant nobody had asked about: the paper states it found no earlier published conjecture concerning this value. Below the catalog's reciprocal-Fermat nonnormality entry at 18, which concerns a named constant with a literature behind it, and well below the Erdos-Borwein 2-density entry at 25, which answers a 2002 question of Crandall. Above the machine-generated band, because the mixed-prime case is a recognisable target inside the Stoneham and Bailey-Crandall programme of explicit normal values that the paper cites as its closest precedent.",
+      sourceUrl: `${REPO}/tree/${SHA}`,
+      sourceName: "GitHub repository, pinned to the reviewed commit",
+    },
+    links: [
+      {
+        kind: "paper",
+        label: "The nine-page paper",
+        url: `${REPO}/blob/${SHA}/paper/localized-logarithm-normality.pdf`,
+      },
+      {
+        kind: "lean-statement",
+        label: "Challenge.lean: the trusted statement, Mathlib only",
+        url: `${REPO}/blob/${SHA}/Challenge.lean`,
+      },
+      {
+        kind: "lean-proof",
+        label: "The proof development, module by module",
+        url: `${REPO}/tree/${SHA}/XiNormality`,
+      },
+      {
+        kind: "other",
+        label: "GitHub Actions: pinned build and axiom audit, passed 9 Sep 2026",
+        url: `${REPO}/actions/runs/34369628677`,
+      },
+      {
+        kind: "other",
+        label: "Dibag 1989, where the localized logarithms come from",
+        url: "https://doi.org/10.1016/0021-8693(89)90180-4",
+      },
+    ],
+    message: [
+      "Approved and published. Thank you for building it so it could be checked.",
+      "",
+      "What I verified rather than took on trust: Challenge.lean imports only Mathlib, writes the constant out in full and states normality with no project-defined predicate to hide behind and no extra hypothesis that could carry an unproven input; Solution.lean bridges to the development; Audit.lean pins the axiom lists with #guard_msgs so a changed list is a build error; and the GitHub Actions run of 9 September built the pipeline from the pinned toolchain and mathlib commit and passed, which puts the kernel check on a machine other than yours. I did not rebuild it locally.",
+      "",
+      "One correction, and it is to your note rather than to the paper. You wrote that the real point is normality for a natural constant, a number not constructed with the purpose of being normal. The paper is more careful: it says the one-prime values already belong to an established normal family, names Stoneham 1973 and Bailey-Crandall 2002 as the exact precedent, and states it has not located an earlier published conjecture about this value. So the entry records the result as the mixed-prime extension of that programme: real work, since every index 2^a 3^c contributes at once, but a different claim from the one your note makes.",
+      "",
+      "Significance is 15. That axis measures how much mathematics cared before the answer, and nobody had posed this question, so it sits below the reciprocal-Fermat nonnormality entry at 18 and the Erdos-Borwein 2-density entry at 25, both constants with a literature behind them.",
+      "",
+      "Two housekeeping notes. The source URL is pinned to commit 0696181 rather than to main, since the repository is the whole evidentiary basis and a branch can move. And your AI-role claim is recorded as your account: the repository credits describe an AI-assisted project without separating model from human, and the paper has no byline, so the entry says that rather than asserting autonomy the public record does not show.",
+    ].join("\n"),
+  },
+  {
+    slug: "the-topology-of-gromov-hausdorff-space",
+    action: "reject",
+    reason: "held",
+    edits: {
+      // HTML-escaped ampersand, which is not an allowed choice value and would
+      // refuse any later edit of the entry. Fixed now so the row is publishable
+      // on the day the claim stands up.
+      fieldGroup: "Geometry & topology",
+    },
+    reviewNote:
+      "Held 10 Sep 2026 under the extraordinary-claims rule: arXiv 2609.09639 v1, 87 pages, one day old, claiming the Gromov-Hausdorff space is homeomorphic to l^2. Nothing on the row is wrong and nothing was changed except status, reason, message and one data fix - fieldGroup arrived HTML-escaped as \"Geometry &amp; topology\", which is not an allowed choice value and would have refused any later edit. Re-publish as submitted once a named expert with no stake has checked the argument, the paper is accepted, or a machine-checked proof exists; watch arXiv 2609.09639 for v2 and for commentary. Ishiki is established in exactly this area and the AI disclosure is exemplary, so this is a timing decision, not a doubt.",
+    message: [
+      "Held rather than declined, and this is not a judgement on the mathematics.",
+      "",
+      "You asked directly whether the site's independent-verification requirement applies here. It does. The methodology's extraordinary-claims rule says a claim that would be a major result by any expert's standard is not published at Unreviewed, and not published as a Candidate either, because a listing here puts the site's name beside a claim it has not read. A complete topological classification of the Gromov-Hausdorff space is such a claim, and it arrived as an 87-page version 1 that was one day old. Nobody has read it yet, here or anywhere.",
+      "",
+      "The rule is about the size of the claim, not about the author or the submitter. Ishiki is established in exactly this area, the KAKENHI support and the earlier work the paper builds on are real, and the AI disclosure is exemplary: it names Codex on GPT-6, says what the model was used for, and states that the author verified every argument and takes full responsibility. Your submission was accurate about all of it, including that author checking alone does not meet the bar. The same rule has already held a Yau-Tian-Donaldson disproof and a positive-curvature claim, both by established authors.",
+      "",
+      "The way back, any one of these:",
+      "- a named expert with no stake in the work says publicly that they have checked the argument;",
+      "- the paper is accepted by a journal;",
+      "- a machine-checked proof of the main theorem exists.",
+      "",
+      "Send it again on any of those and it goes in at the tier it has earned. Your text is kept on the row, so nothing has to be written twice.",
+      "",
+      "Two things worth saying about the submission itself. Flagging that Antonyan (2020) records the questions rather than being an independently established earliest date was exactly right. And separating the main classification theorem from the absolute-retract theorem and the intermediate constructions is the correct division; if this comes back, that is the shape the entry will take.",
+    ].join("\n"),
+  },
+];
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  if (LINT) {
+    let over = 0;
+    for (const d of DECISIONS) {
+      const n = d.message.length;
+      console.log(`${d.slug.slice(0, 50).padEnd(50)} message ${n}/${MESSAGE_MAX}${n > MESSAGE_MAX ? "  OVER" : ""}`);
+      if (n > MESSAGE_MAX) over++;
+    }
+    process.exitCode = over ? 1 : 0;
+    return;
+  }
+  const db = await connectWithRetry();
+  console.log(`database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`);
+
+  const curator = await prisma.user.findFirst({
+    where: { pseudonym: "Rasmus Lindahl" },
+    select: { id: true, pseudonym: true },
+  });
+
+  let bad = 0;
+  for (const d of DECISIONS) {
+    const cur = await prisma.problem.findUnique({
+      where: { slug: d.slug },
+      select: {
+        id: true,
+        status: true,
+        name: true,
+        sourceUrl: true,
+        submittedById: true,
+        links: { select: { label: true, url: true } },
+      },
+    });
+    if (!cur) throw new Error(`not found on ${db}: ${d.slug}`);
+    if (cur.status !== "pending")
+      throw new Error(`${d.slug} is ${cur.status}, not pending`);
+
+    console.log(
+      `${d.action === "reject" ? "HOLD   " : "APPROVE"}  ${cur.name.slice(0, 60)}`,
+    );
+    console.log(
+      `  message : ${d.message.length}/${MESSAGE_MAX}${d.message.length > MESSAGE_MAX ? "  OVER" : ""}`,
+    );
+    if (d.message.length > MESSAGE_MAX) bad++;
+
+    for (const [k, v] of Object.entries(d.edits ?? {}))
+      console.log(
+        `  ${k.padEnd(17)}: ${typeof v === "string" ? `${v.length} chars` : JSON.stringify(v)}`,
+      );
+    for (const l of d.links ?? []) {
+      console.log(
+        `  link (${l.kind}) ${l.label.length}/${LINK_LABEL_MAX}: ${l.label}`,
+      );
+      if (l.label.length > LINK_LABEL_MAX) bad++;
+    }
+
+    // The same check the guarded client runs on write, against the MERGED
+    // result, so the dry run reports what the write would rather than
+    // promising success and failing later.
+    const merged = [...cur.links, ...(d.links ?? [])];
+    const v = checkStoredEntry({
+      specs: SPECS,
+      fields: d.edits ?? {},
+      links: merged,
+      sourceUrl:
+        ((d.edits?.sourceUrl as string | undefined) ?? cur.sourceUrl) || null,
+    });
+    console.log(`  field check: ${v.length ? "FAILED" : "ok"}`);
+    for (const x of v) console.log(`    - ${x.field}: ${x.problem}`);
+    bad += v.length;
+    if (!cur.submittedById) console.log("  NOTE: no submitter, no message sent");
+    console.log();
+  }
+  if (bad) throw new Error(`${bad} violation(s) - nothing written`);
+
+  if (!APPLY) {
+    console.log("DRY RUN - pass --apply to write");
+    return;
+  }
+  if (!curator) throw new Error("curator not found on this database");
+
+  // Written one statement at a time rather than in $transaction: the guard is
+  // a query extension, and keeping the writes on the extended client is worth
+  // more here than atomicity across three rows. If a later write fails, the
+  // failure names which decision and which step, and re-running is safe
+  // because the pending check above refuses an already-decided entry.
+  for (const d of DECISIONS) {
+    const cur = await prisma.problem.findUnique({
+      where: { slug: d.slug },
+      select: { id: true, submittedById: true, _count: { select: { links: true } } },
+    });
+    if (!cur) throw new Error(`vanished: ${d.slug}`);
+    const n = cur._count.links;
+
+    await prisma.problem.update({
+      where: { id: cur.id },
+      data: {
+        ...(d.edits ?? {}),
+        ...(d.links?.length
+          ? { links: { create: d.links.map((l, i) => ({ ...l, position: n + i })) } }
+          : {}),
+        status: d.action === "approve" ? "published" : "rejected",
+        reviewedAt: new Date(),
+        reviewMessage: d.message,
+        reviewReason: d.reason,
+      } as never,
+    });
+    console.log(`updated: ${d.slug}`);
+
+    if (cur.submittedById) {
+      await prisma.directMessage.create({
+        data: {
+          userId: cur.submittedById,
+          senderId: curator.id,
+          senderName: curator.pseudonym,
+          kind: "decision",
+          reason: d.reason,
+          body: d.message.slice(0, MESSAGE_MAX),
+          problemId: cur.id,
+        },
+      });
+      console.log(`messaged: ${d.slug}`);
+    }
+
+    await prisma.problemActivity.create({
+      data: {
+        problemId: cur.id,
+        userId: curator.id,
+        userName: curator.pseudonym,
+        type: d.action === "approve" ? "approved" : "rejected",
+      },
+    });
+
+    if (d.reviewNote) {
+      await prisma.reviewNote.create({
+        data: {
+          problemId: cur.id,
+          userId: curator.id,
+          userName: curator.pseudonym,
+          body: d.reviewNote,
+        },
+      });
+      console.log(`review note: ${d.slug}`);
+    }
+  }
+
+  console.log("\nAPPLIED. Every public surface lags by up to an hour: these are");
+  console.log("writes straight to the database, so nothing revalidates a tag.");
+  console.log("A deploy clears it.");
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/review-2026-09-12-b.ts
+++ b/scripts/review-2026-09-12-b.ts
@@ -1,0 +1,506 @@
+// Review of the four submissions that arrived 11-12 September 2026, after
+// the morning dump. Three approved with edits, one held. Plus one correction
+// message to a submitter declined earlier today for a reason that was wrong.
+//
+// ---------------------------------------------------------------------------
+// MORRIS'S CONJECTURE, k = 4 (Liu; Zenodo 22702735) - approved, Candidate as
+// submitted, unreviewed, ai-co-developed, significance 15.
+//
+// Morris (2006, Conjecture 2) conjectured FC(k,n) = Theta(n^{k-2}) for every
+// fixed k >= 2. The manuscript records that Pulaj settled k = 3 exactly
+// (FC(3,n) = floor(n/2)+1 for n >= 4), so four-uniform is the first open
+// case, and proves FC(4,n) = Theta(n^2) with explicit bounds
+// r(n-3r)+1 <= FC(4,n) <= 1 + floor(160 n(n-1)/3) for n >= 20, r = floor(n/6).
+//
+// Checked: the Zenodo record exists with the abstract as submitted (V1,
+// 11 Sep, one author); the manuscript's AI statement was read and is quoted
+// in full in aiRole - it is a co-development statement, with the finite
+// classification FC(4,9) = 16 "developed primarily by the models" and the
+// author proposing the four-set extension; the companion GitHub release V1
+// holds the exact certificates and Python/C++ verifiers. Zenodo's PDF blocks
+// automated download; the copy read here came through a browser fetch. None
+// of the mathematics was checked and the verifiers were not run. Candidate
+// is what the submitter asked for and is right for a one-day-old single-
+// author preprint.
+//
+// Not extraordinary: one uniformity of a conjecture known inside the
+// union-closed subcommunity. Significance 15, below Daykin-Frankl at 25.
+//
+// ---------------------------------------------------------------------------
+// BOLLOBAS-NIKIFOROV (Coutinho, Liu, Spier, Tang, Zhang) - approved, tier
+// LIFTED from Lean-checked to Lean-verified, Candidate as submitted,
+// ai-co-developed, significance 30.
+//
+// A full proof of a named 2007 conjecture (JCTB) that stayed open through
+// 2026 - Lin-Ning-Wu did triangle-free, Zhang regular, then few-triangles,
+// complete multipartite, and a.a.s. for random graphs. The rule for a claim
+// this size is: held until a named expert has checked it OR a formal proof
+// exists. A formal proof exists, and the question is whether its statement
+// is faithful. It is, and it was audited here at the reviewed commit edb5259:
+//
+//   1. Challenge.lean imports only Mathlib. The headline theorem
+//      lambda1_sq_add_lambda2_sq_le is stated entirely in Mathlib
+//      vocabulary: G : SimpleGraph V on a Fintype, G ≠ ⊤ for non-complete,
+//      [Nontrivial V] for at least two vertices, G.cliqueNum for omega,
+//      G.edgeFinset.card for |E(G)| counted once, and lambda1/lambda2 as
+//      indices 0 and 1 of Mathlib's eigenvalues₀ of the real adjacency
+//      matrix - which is nonincreasing (the development uses
+//      eigenvalues₀_antitone). The inequality reads
+//      lambda1^2 + lambda2^2 <= 2 (1 - 1/omega) |E|. That is the conjecture.
+//   2. No hypothesis beyond those; nothing project-defined in the statement
+//      except the two thin wrappers, whose definitions sit in the same file.
+//   3. Solution.lean supplies the same five names from the development;
+//      comparator.json compares them with only the three standard axioms
+//      and enable_nanoda: true - the independent kernel. VERIFICATION.md
+//      records the local comparator run ("Nanoda kernel accepts the
+//      solution"); Palomar checks and Lean Action CI both passed on GitHub
+//      at the reviewed commit.
+//   4. No sorry outside the five deliberate holes in Challenge.lean, no
+//      axiom, no native_decide, no unsafe in BN/.
+//
+// So Lean-verified: kernel-checked AND the formal statement anchored, here,
+// against pure Mathlib. The submitter's reason for choosing Lean-checked
+// was "no independent third party has yet audited the correspondence";
+// this review is that audit for the site's purposes, and the note says so.
+//
+// Candidate rather than Resolved, following the Köthe and Smale precedent
+// (Lean-verified + Candidate until a named expert with no stake confirms).
+// The residual here is smaller than there - the statement is pure Mathlib -
+// and the note says what flips it.
+//
+// Publication: announcement, as submitted; the manuscript is a preliminary
+// note in the repository, not on arXiv. sourceUrl pinned to the commit.
+//
+// ---------------------------------------------------------------------------
+// KOMLOS AND BECK-FIALA (Guo, Fang, Lu; arXiv 2609.11189) - HELD under the
+// extraordinary-claims rule.
+//
+// Claims the full Komlós conjecture with constant 3 sqrt(2 pi), which gives
+// Beck-Fiala as a corollary. Komlós (1981) is one of the central open
+// problems of discrepancy theory; Banaszczyk's O(sqrt(log n)) has stood
+// since 1998. An 18-page v1, one day old, no formalization, no endorsement,
+// and the proof attributed to an agent the paper does not describe. This is
+// exactly the rule's case, and the same submitter's Gromov-Hausdorff claim
+// was held on the same grounds two days ago.
+//
+// Not a judgement on the mathematics. Nothing on the row is changed. The
+// statement field is the abstract, not the question; that needs rewriting
+// if it comes back, and the review note says so.
+//
+// FOR THE CURATOR, not this script: the same team's Talagrand convolution
+// entry (sig 37) was published on 19 August as Resolved / Unreviewed, before
+// the 2 September rule. The Yau-Tian-Donaldson entry was held retroactively
+// when the rule arrived. Whether the Talagrand entry gets the same treatment
+// is a decision, not a review.
+//
+// ---------------------------------------------------------------------------
+// COMPLEX GROTHENDIECK LOWER BOUND (same team; arXiv 2609.07000) - approved,
+// Partial as submitted, unreviewed, ai-discovered at face value, sig 30.
+//
+// K_G^C > 1.35584631827168, up from Davie's ~1.33807, against Haagerup's
+// upper bound ~1.40491. A record on a classical constant, not a resolution,
+// so partial - which is exactly how this catalog files rank records, prime
+// gap records and the matrix multiplication exponent. Not extraordinary.
+// The numerical part is certified by Arb ball arithmetic with the code and
+// exact inputs as arXiv ancillary files and in a linked repository; not run
+// here. The disclosure is the same one sentence as the Talagrand entry, and
+// aiRole handles it the same way: face value, model maker left empty.
+//
+// ---------------------------------------------------------------------------
+// GOMILA, Lambda <= 0.1787854 - correction message, no status change.
+//
+// Declined this morning with the message that "records of exactly this kind
+// are tracked here as Frontiers, not as entries". That is not the site's
+// practice: prime-gaps-at-most-186, elliptic-curve-rank-record-thirty-one,
+// matrix-multiplication-exponent-2371177 and dozens more are entries with
+// resolution partial, and frontier rows link to them. The decline's other
+// grounds stand - the form carried the submitter's name as the entry name,
+// no statement, no field - but the reason given was wrong and the submitter
+// is told so, with the invitation to resubmit in proper shape.
+//
+// ---------------------------------------------------------------------------
+// --lint runs every local check with no database. Dry run by default. Pass
+// --apply to write. Production writes are the curator's to run.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+import { checkStoredEntry } from "../src/lib/field-validation";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { MESSAGE_MAX } from "../src/lib/messages";
+import { charLength, canonical } from "../src/lib/char-length";
+
+const APPLY = process.argv.includes("--apply");
+const LINT = process.argv.includes("--lint");
+const SPECS = [...EDITABLE_FIELDS, ...CURATOR_FIELDS];
+const LINK_LABEL_MAX = 120;
+
+const BN_REPO = "https://github.com/ShengtongZhang-alt/BN";
+const BN_SHA = "edb5259dfd055ea31b4c46ac9ea4d33a758c2b99";
+
+interface Decision {
+  slug: string;
+  action: "approve" | "reject";
+  reason: string;
+  message: string;
+  edits?: Record<string, unknown>;
+  links?: { label: string; url: string; kind: string }[];
+  reviewNote?: string;
+}
+
+const DECISIONS: Decision[] = [
+  {
+    slug: "four-uniform-case-of-morris-s-conjecture-mathrm-fc-4-n-theta-n-2",
+    action: "approve",
+    reason: "edited",
+    edits: {
+      shortName: "Morris's conjecture, k = 4",
+      resultNote:
+        "It is proved that $\\mathrm{FC}(4,n)=\\Theta(n^2)$, settling the four-uniform case of Morris's conjecture; the three-uniform case had been settled exactly by Pulaj, so this was the first open uniformity. Explicitly, for $n\\ge 20$ and $r=\\lfloor n/6\\rfloor$, $r(n-3r)+1\\le\\mathrm{FC}(4,n)\\le 1+\\lfloor\\tfrac{160}{3}n(n-1)\\rfloor$, and with the Chung-Frankl triple-star theorem $\\mathrm{FC}(4,n)\\le(18+o(1))n^2$. The key step is a sharp sunflower criterion: four-sets with a common two-point core and pairwise disjoint two-point petals form a Frankl-complete configuration if and only if there are at least nine petals, the positive direction by a charging inequality with weight three on the core and one on the petals. Separately, exact certificates establish $\\mathrm{FC}(4,9)=16$ and refute Pulaj and Wood's lexicographic extremality conjecture. The paper also explains why higher-uniformity sunflowers cannot supply the same local forcing, so the general conjecture stays open.",
+      aiRole:
+        "The manuscript's AI statement, in full: \"The author and AI models both made substantial mathematical contributions to this work. The finite classification establishing $\\mathrm{FC}(4,9)=16$ was developed primarily by the models. The author proposed extending this work to the four-set case of Morris's conjecture and contributed to proof development and refinement. The collaboration developed the charging inequality, $3:1$ core-petal weights, and matching negative certificates for the sharp nine-petal sunflower threshold, and combined this local criterion with extremal bounds to prove $\\mathrm{FC}(4,n)=\\Theta(n^2)$. GPT-6 Astra (OpenAI) and Fable 5.1 (Anthropic) contributed to proof exploration, computation, and review. The author takes full responsibility for all mathematical results and the contents of this manuscript.\" Co-developed on that account: the models carried the finite classification and shared the main argument, the author set the target and takes responsibility.",
+      verificationNote:
+        "Zenodo preprint V1, published 11 September 2026, one author, no independent endorsement. Checked here: the record exists with the abstract as submitted; the manuscript states Morris's Conjecture 2 as the entry does and records that Pulaj settled the three-uniform case exactly ($\\mathrm{FC}(3,n)=\\lfloor n/2\\rfloor+1$ for $n\\ge 4$), so this is the first open uniformity and not a duplicate of anything in the catalog; the companion repository release V1 holds the exact certificates for $\\mathrm{FC}(4,9)=16$ and for the Pulaj-Wood refutation with Python and C++ verifiers. None of the mathematics was checked here and the verifiers were not run. Filed as Candidate, as submitted, until an independent reader has been through the argument or the finite certificates have been replayed.",
+      significance: 15,
+      significanceNote:
+        "One uniformity of a named 2006 conjecture of Morris in the union-closed literature, and the first open case after Pulaj settled k = 3. Known to the people who work on Frankl's conjecture and to nobody else. Below the Daykin-Frankl entry at 25, which is a conjecture in its own right, and level with the Elton-Odell and Dittert-dimension-16 entries at 15: a specific case of a subcommunity conjecture.",
+    },
+    message: [
+      "Approved and published as Candidate, as you asked, at Unreviewed.",
+      "",
+      "What was checked: the Zenodo record and its abstract; the manuscript's AI statement, which is now quoted in full on the entry rather than paraphrased; that Morris's Conjecture 2 is as you stated it and that Pulaj's exact result for k = 3 makes four-uniform the first open case; and that the V1 release holds the certificates and verifiers. The mathematics was not checked and the verifiers were not run, which is why Candidate is the right status for a one-day-old preprint. If someone independent reads it, or the finite certificates get replayed, say so and it moves.",
+      "",
+      "Edits: the short name is plain text (that field renders raw, so the $k=4$ showed as dollars); the result note now carries the explicit bounds from Theorem 1.1 and the Pulaj context; the verification note says what was and was not checked. Significance 15: one case of a conjecture known inside a single subcommunity, below Daykin-Frankl at 25.",
+      "",
+      "Nothing else changed. The two links you gave, the certificates release and Morris's paper, are exactly right.",
+    ].join("\n"),
+  },
+  {
+    slug: "bollobas-nikiforov-conjecture",
+    action: "approve",
+    reason: "edited",
+    edits: {
+      statement:
+        "Let $G$ be a finite simple graph with $m=|E(G)|$ edges and clique number $\\omega(G)$, and let $\\lambda_1(G)\\ge\\lambda_2(G)\\ge\\cdots\\ge\\lambda_n(G)$ be the eigenvalues of its adjacency matrix. Bollobás and Nikiforov conjectured in 2007 that every non-complete graph satisfies $$\\lambda_1(G)^2+\\lambda_2(G)^2\\le 2\\Bigl(1-\\frac{1}{\\omega(G)}\\Bigr)m.$$ Before this work it was known for triangle-free graphs (Lin, Ning and Wu), regular graphs (Zhang), graphs with few triangles, complete multipartite graphs, and asymptotically almost surely for random graphs, and open in general.",
+      model: "GPT-6 Astra; Grok 4.6; Claude Fable 5.1",
+      modelMaker: "OpenAI; xAI; Anthropic",
+      verification: "lean-verified",
+      verificationNote:
+        "Lifted from the submitted Lean-checked to Lean-verified, because the correspondence the submitter said nobody had audited was audited here, on 12 September 2026, at commit edb5259. Challenge.lean imports only Mathlib and states the headline theorem entirely in Mathlib vocabulary: $G$ a SimpleGraph on a finite vertex type, $G\\ne\\top$ for non-complete, Nontrivial for at least two vertices, G.cliqueNum for $\\omega$, G.edgeFinset.card for $|E(G)|$ counted once, and $\\lambda_1,\\lambda_2$ as the first two entries of Mathlib's eigenvalues₀ of the real adjacency matrix, which is nonincreasing. There is no hypothesis beyond those and nothing project-defined in the statement beyond those two thin wrappers, whose definitions sit in the same file. Solution.lean supplies the same five names from the development; comparator.json compares them with only propext, Classical.choice and Quot.sound permitted and with nanoda enabled as an independent kernel; VERIFICATION.md records the comparator run accepting the solution under both kernels; Palomar checks and Lean Action CI passed on GitHub at the reviewed commit. No sorry outside the five deliberate holes in Challenge.lean, no axiom, no native_decide. The build was not repeated here. Candidate rather than Resolved is the site's practice for named conjectures with a formal proof: it flips when a named expert with no stake confirms publicly that the formal statement is the conjecture, a short read since the statement is pure Mathlib.",
+      significance: 30,
+      significanceNote:
+        "A named 2007 conjecture from a JCTB paper, with a nineteen-year trail of partial results - triangle-free, regular, few triangles, complete multipartite, random graphs - and its own problem record. Famous within spectral graph theory and unknown outside it, which is the band's definition. Level with the Albertson-Berman induced-forest and Hadamard-668 entries at 30; below the Petersen colouring conjecture at 40, which reaches the whole of graph theory.",
+      sourceUrl: `${BN_REPO}/tree/${BN_SHA}`,
+      sourceName:
+        "GitHub repository (Lean 4 proof and preliminary note), pinned to the reviewed commit",
+    },
+    links: [
+      {
+        kind: "lean-statement",
+        label: "Challenge.lean: the five statements against plain Mathlib, at the reviewed commit",
+        url: `${BN_REPO}/blob/${BN_SHA}/Challenge.lean`,
+      },
+      {
+        kind: "lean-proof",
+        label: "Solution.lean: the comparator-checked bridge to the development",
+        url: `${BN_REPO}/blob/${BN_SHA}/Solution.lean`,
+      },
+      {
+        kind: "other",
+        label: "VERIFICATION.md: the recorded comparator and nanoda run",
+        url: `${BN_REPO}/blob/${BN_SHA}/VERIFICATION.md`,
+      },
+    ],
+    message: [
+      "Approved and published, at Lean-verified rather than the Lean-checked you selected, and as Candidate as you selected. Both are explained on the entry; here is the short version.",
+      "",
+      "You chose Lean-checked because no independent third party had audited the informal-to-formal correspondence. That audit is what this review did. Challenge.lean imports only Mathlib and states the headline theorem in Mathlib's own vocabulary - SimpleGraph, G ≠ ⊤, Nontrivial, cliqueNum, edgeFinset.card, and the first two entries of eigenvalues₀, which Mathlib orders nonincreasingly - with no hypothesis beyond those and nothing project-defined in the statement beyond the two wrappers whose definitions are in the same file. That is the Bollobás-Nikiforov inequality. With comparator, nanoda, Palomar and Lean Action all green at edb5259, that is Lean-verified by this site's definition: kernel-checked and the statement anchored.",
+      "",
+      "Candidate rather than Resolved is the site's practice for named conjectures with a formal proof and no outside expert yet on record (Köthe and Smale sit the same way). It flips when a named expert with no stake confirms publicly that the formal statement is the conjecture. Since the statement is pure Mathlib, that is a short read for anyone in spectral graph theory, and the arXiv posting you mention will probably bring it.",
+      "",
+      "Other edits: the statement uses $ delimiters (the \\( form does not render here) and now records the prior partial results; the model field lists all three systems with their roles in your disclosure; the source URL is pinned to the reviewed commit; three links added to the statement, the bridge and the verification record. Significance 30: famous within one research community.",
+      "",
+      "This is the cleanest statement surface this site has seen. Thank you.",
+    ].join("\n"),
+  },
+  {
+    slug: "komlos-and-beck-fiala-conjectures",
+    action: "reject",
+    reason: "held",
+    reviewNote:
+      "Held 12 Sep 2026 under the extraordinary-claims rule: arXiv 2609.11189 v1, 18 pages, one day old, claiming the full Komlós conjecture with constant 3 sqrt(2 pi) and Beck-Fiala as a corollary, proof attributed to an 'Odin Automatic AI Research Agent' the paper does not describe. Nothing on the row changed. If it comes back: the statement field is the paper's abstract and must be rewritten as the question (Komlós 1981: is there a universal constant K such that every family of unit vectors admits a signing with l-infinity norm at most K?); significance would sit around 50; the disclosure is one sentence and should be handled as on the Talagrand convolution entry. Watch arXiv for v2 and for discrepancy-theory commentary (Bansal, Dadush, Garg, Lovett, Meka, Rothvoss, Nikolov). Same submitter as the held Gromov-Hausdorff entry and the published Talagrand and Grothendieck entries.",
+    message: [
+      "Held rather than declined, and not a judgement on the mathematics.",
+      "",
+      "The methodology's extraordinary-claims rule: a claim that would be a major result by any expert's standard is not published at Unreviewed and not published as a Candidate either, because a listing here puts the site's name beside a claim it has not read. A proof of the Komlós conjecture - the full conjecture, with a universal constant, and Beck-Fiala with it - is a landmark of discrepancy theory by any standard; Banaszczyk's square-root-log bound has stood since 1998. It arrived as an 18-page version 1 that was one day old, with no formalization, no endorsement, and the proof attributed to an agent the paper describes in one sentence. Nobody has read it yet, here or anywhere. Your Gromov-Hausdorff submission was held on the same grounds two days ago, and this one is a larger claim.",
+      "",
+      "The way back, any one of these: a named expert with no stake in the work says publicly that they have checked the argument; the paper is accepted by a journal; or a machine-checked proof of Theorem 1.1 exists. Send it again on any of those and it goes in at the tier it has earned.",
+      "",
+      "Two things to fix when it returns, so you know now. The statement field currently holds the paper's abstract; the site wants the question as it was posed - Komlós, 1981: is there a universal constant such that every finite family of unit vectors admits a signing of bounded l-infinity norm? And the AI disclosure is one sentence; if the authors can say what Odin is and how it was run, the entry can say more than 'taken at face value'.",
+      "",
+      "Your Grothendieck submission from the same team, a record rather than a resolution, is published today; the two are not treated alike because the claims are not alike in size.",
+    ].join("\n"),
+  },
+  {
+    slug: "lower-bound-for-the-complex-grothendieck-constant",
+    action: "approve",
+    reason: "edited",
+    edits: {
+      statement:
+        "What is the exact value of the complex Grothendieck constant $K_G^{\\mathbb C}$, the least $K$ such that $\\bigl|\\sum_{i,j}a_{ij}\\langle x_i,y_j\\rangle\\bigr|\\le K\\max_{|\\varepsilon_i|=|\\delta_j|=1}\\bigl|\\sum_{i,j}a_{ij}\\varepsilon_i\\delta_j\\bigr|$ for every complex matrix $(a_{ij})$ and all unit vectors $x_i,y_j$ in any complex Hilbert space? Grothendieck proved it finite in 1953. Before this work the best bounds were Davie's lower bound of about $1.33807$ and Haagerup's 1987 upper bound of about $1.40491$; the value is open, and this entry records progress on the lower bound.",
+      posedBy:
+        "Alexandre Grothendieck, Résumé (1953); the value of the complex constant an explicit open question at least since Haagerup's 1987 upper bound",
+      modelMaker: null,
+      aiRole:
+        "The paper's disclosure is one sentence, in the abstract and again under the heading \"The role of AI in this proof\": \"Odin Automatic AI Research Agent was used to derive the lower bound and the proof.\" Taken at face value, as this site's classification rule requires, that is an AI-discovered claim, and it is the same disclosure this team gave for its Talagrand convolution entry. The paper says nothing about what Odin is, which models it runs on, or how it was steered, and no public description of the system was found, so the model maker is left empty rather than guessed at. The three named humans are Shengtao Guo, Ethan X. Fang and Junwei Lu.",
+      verificationNote:
+        "Unreviewed arXiv preprint, v1 of 7 September 2026, with no independent endorsement and no peer review. The numerical part is certified by Arb ball arithmetic with outward rounding; the verification code and the exact rational inputs are supplied as arXiv ancillary files and in the linked repository, and were not run here. The analytic part - the dimension-independent $L_\\infty$-to-$L_1$ estimate for the weighted Gaussian Hermite multipliers that turns the certified numbers into a bound on $K_G^{\\mathbb C}$ - was not checked. Checked here: the arXiv record and abstract as submitted, that Davie's and Haagerup's bounds are as the paper states them, and that the catalog holds no entry on either Grothendieck constant, so the 2026 real-constant improvements the submitter mentions are not duplicates. Partial: a better lower bound, not the value.",
+      significance: 30,
+      significanceNote:
+        "The exact value of Grothendieck's constant is a classical open problem of functional analysis with reach into optimization and computer science; the complex case has carried its own literature since Haagerup's 1987 bound and gets less attention than the real one. Level with the Albertson-Berman and Hadamard-668 entries at 30, above the kissing-number-in-19-dimensions record at 25, below the binary-code upper-bounds entry at 39, which sits on a question the whole of coding theory asks.",
+    },
+    links: [
+      {
+        kind: "code",
+        label: "Interval-arithmetic certificates and verifiers (repository named in the paper)",
+        url: "https://github.com/shengtaoguo/complex-grothendieck-certificates",
+      },
+      {
+        kind: "other",
+        label: "arXiv ancillary files: the same verifiers and exact inputs, frozen with v1",
+        url: "https://arxiv.org/src/2609.07000v1/anc",
+      },
+    ],
+    message: [
+      "Approved and published as Partial at Unreviewed, which is exactly how this catalog files records on a constant - the prime-gap records, the rank records and the matrix multiplication exponent all sit the same way.",
+      "",
+      "Edits: the statement now poses the question (the value of the complex constant, with Davie's and Haagerup's bounds as the state of play) rather than carrying the abstract; posedBy names Grothendieck 1953 with Haagerup 1987 as where the complex value became an explicit question; the verification note says what was checked (the record, the bounds, no duplicate on either constant) and what was not (the verifiers were not run, the analytic estimate was not read). Your note that the real-constant improvements are distinct was checked and is right.",
+      "",
+      "Two things on the AI side, handled the same way as your Talagrand entry. The disclosure is one sentence, so AI-discovered is recorded at face value and the model maker is left empty rather than guessed at. If the authors can say anywhere public what Odin is and how it is run, send that and the entry will say more.",
+      "",
+      "Significance 30, level with the Albertson-Berman and Hadamard-668 entries. Two links added: the certificates repository the paper names, and the arXiv ancillary files, which are the same code frozen with v1.",
+    ].join("\n"),
+  },
+];
+
+/// Messages that are not decisions: sent as notes on entries already decided.
+const NOTES: { slug: string; body: string }[] = [
+  {
+    slug: "jude-gomila",
+    body: [
+      "A correction to this morning's decline, from the reviewer who wrote it.",
+      "",
+      "I told you that records of this kind are tracked here as Frontiers and not as entries. That is wrong, and I should have checked before writing it. The catalog files record improvements as entries with resolution Partial - the prime-gap records, the elliptic-curve rank records, the matrix multiplication exponent, the kissing number in 19 dimensions all sit that way - and a frontier row links to the entry when a frontier exists. A better upper bound on the de Bruijn-Newman constant is exactly that kind of result, and a complex Grothendieck lower bound was published today on those terms.",
+      "",
+      "What did stand in the way was the form: the entry name arrived as your own name, and there was no statement, no field and no links, so there was no text to review. If you resubmit with those filled - the question (Newman's conjecture and the history of upper bounds on Lambda), the field (analytic number theory), the entry name, and the release tag or commit your sealed SHA256SUMS attest - it will be reviewed on its merits as a Partial, Unreviewed entry, with the external referee report and the ongoing expert reworking noted as they are in your README. If you would rather I draft the statement from the README and send it to you to correct, reply here and I will.",
+      "",
+      "The extraordinary-claims rule does not apply to a bound improvement, so nothing about the size of the claim holds it back.",
+    ].join("\n"),
+  },
+];
+
+/// The serverless cluster refuses the first connection after idling.
+async function connectWithRetry(prisma: {
+  $queryRawUnsafe: <T>(q: string) => Promise<T>;
+}): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+function lint(): number {
+  let bad = 0;
+  const limit = new Map<string, number>();
+  for (const s of SPECS) if (s.maxLength) limit.set(s.key, s.maxLength);
+  for (const d of DECISIONS) {
+    console.log(`${d.action === "reject" ? "HOLD   " : "APPROVE"}  ${d.slug.slice(0, 64)}`);
+    const mlen = charLength(canonical(d.message));
+    console.log(`  message : ${mlen}/${MESSAGE_MAX}${mlen > MESSAGE_MAX ? "  OVER" : ""}`);
+    if (mlen > MESSAGE_MAX) bad++;
+    for (const [k, v] of Object.entries(d.edits ?? {})) {
+      if (typeof v === "string") {
+        const n = charLength(canonical(v));
+        const lim = limit.get(k);
+        const over = lim !== undefined && n > lim;
+        console.log(`  ${k.padEnd(17)}: ${n}${lim ? `/${lim}` : ""}${over ? "  OVER" : ""}`);
+        if (over) bad++;
+      } else console.log(`  ${k.padEnd(17)}: ${JSON.stringify(v)}`);
+    }
+    for (const l of d.links ?? []) {
+      console.log(`  link (${l.kind}) ${l.label.length}/${LINK_LABEL_MAX}: ${l.label}`);
+      if (l.label.length > LINK_LABEL_MAX) bad++;
+    }
+    const v = checkStoredEntry({ specs: SPECS, fields: d.edits ?? {} });
+    for (const x of v) console.log(`  RULE: ${x.field}: ${x.problem}`);
+    bad += v.length;
+    console.log();
+  }
+  for (const n of NOTES) {
+    const len = charLength(canonical(n.body));
+    console.log(`NOTE     ${n.slug}\n  message : ${len}/${MESSAGE_MAX}${len > MESSAGE_MAX ? "  OVER" : ""}\n`);
+    if (len > MESSAGE_MAX) bad++;
+  }
+  return bad;
+}
+
+async function main() {
+  const localBad = lint();
+  if (LINT) {
+    console.log(localBad ? `${localBad} local violation(s)` : "local checks ok");
+    process.exitCode = localBad ? 1 : 0;
+    return;
+  }
+  if (localBad) throw new Error(`${localBad} local violation(s) - nothing written`);
+
+  const prisma = guardedPrisma();
+  try {
+    const db = await connectWithRetry(prisma);
+    console.log(`database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`);
+
+    const curator = await prisma.user.findFirst({
+      where: { pseudonym: "Rasmus Lindahl" },
+      select: { id: true, pseudonym: true },
+    });
+
+    let bad = 0;
+    for (const d of DECISIONS) {
+      const cur = await prisma.problem.findUnique({
+        where: { slug: d.slug },
+        select: {
+          id: true,
+          status: true,
+          name: true,
+          sourceUrl: true,
+          submittedById: true,
+          links: { select: { label: true, url: true } },
+        },
+      });
+      if (!cur) throw new Error(`not found on ${db}: ${d.slug}`);
+      if (cur.status !== "pending") throw new Error(`${d.slug} is ${cur.status}, not pending`);
+      const merged = [...cur.links, ...(d.links ?? [])];
+      const v = checkStoredEntry({
+        specs: SPECS,
+        fields: d.edits ?? {},
+        links: merged,
+        sourceUrl: ((d.edits?.sourceUrl as string | undefined) ?? cur.sourceUrl) || null,
+      });
+      console.log(
+        `${d.action.toUpperCase().padEnd(7)}  ${cur.name.slice(0, 60)}  -> merged check: ${v.length ? "FAILED" : "ok"}`,
+      );
+      for (const x of v) console.log(`    - ${x.field}: ${x.problem}`);
+      bad += v.length;
+      if (!cur.submittedById) console.log("  NOTE: no submitter, no message sent");
+    }
+    for (const n of NOTES) {
+      const cur = await prisma.problem.findUnique({
+        where: { slug: n.slug },
+        select: { status: true, submittedById: true, name: true },
+      });
+      if (!cur) throw new Error(`note target not found: ${n.slug}`);
+      console.log(`NOTE     ${cur.name.slice(0, 60)}  (status ${cur.status}, submitter ${cur.submittedById ? "yes" : "NONE"})`);
+      if (!cur.submittedById) bad++;
+    }
+    if (bad) throw new Error(`${bad} violation(s) - nothing written`);
+
+    if (!APPLY) {
+      console.log("\nDRY RUN - pass --apply to write");
+      return;
+    }
+    if (!curator) throw new Error("curator not found on this database");
+
+    for (const d of DECISIONS) {
+      const cur = await prisma.problem.findUnique({
+        where: { slug: d.slug },
+        select: { id: true, submittedById: true, _count: { select: { links: true } } },
+      });
+      if (!cur) throw new Error(`vanished: ${d.slug}`);
+      const n = cur._count.links;
+
+      await prisma.problem.update({
+        where: { id: cur.id },
+        data: {
+          ...(d.edits ?? {}),
+          ...(d.links?.length
+            ? { links: { create: d.links.map((l, i) => ({ ...l, position: n + i })) } }
+            : {}),
+          status: d.action === "approve" ? "published" : "rejected",
+          reviewedAt: new Date(),
+          reviewMessage: d.message,
+          reviewReason: d.reason,
+        } as never,
+      });
+      console.log(`updated: ${d.slug}`);
+
+      if (cur.submittedById) {
+        await prisma.directMessage.create({
+          data: {
+            userId: cur.submittedById,
+            senderId: curator.id,
+            senderName: curator.pseudonym,
+            kind: "decision",
+            reason: d.reason,
+            body: d.message.slice(0, MESSAGE_MAX),
+            problemId: cur.id,
+          },
+        });
+        console.log(`messaged: ${d.slug}`);
+      }
+
+      await prisma.problemActivity.create({
+        data: {
+          problemId: cur.id,
+          userId: curator.id,
+          userName: curator.pseudonym,
+          type: d.action === "approve" ? "approved" : "rejected",
+        },
+      });
+
+      if (d.reviewNote) {
+        await prisma.reviewNote.create({
+          data: {
+            problemId: cur.id,
+            userId: curator.id,
+            userName: curator.pseudonym,
+            body: d.reviewNote,
+          },
+        });
+        console.log(`review note: ${d.slug}`);
+      }
+    }
+
+    for (const nt of NOTES) {
+      const cur = await prisma.problem.findUnique({
+        where: { slug: nt.slug },
+        select: { id: true, submittedById: true },
+      });
+      if (!cur?.submittedById) continue;
+      await prisma.directMessage.create({
+        data: {
+          userId: cur.submittedById,
+          senderId: curator.id,
+          senderName: curator.pseudonym,
+          kind: "note",
+          body: nt.body.slice(0, MESSAGE_MAX),
+          problemId: cur.id,
+        },
+      });
+      console.log(`note sent: ${nt.slug}`);
+    }
+
+    console.log("\nAPPLIED. New entries render on first request; the lists and");
+    console.log("stats lag by up to an hour, or until a deploy.");
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main();

--- a/scripts/review-2026-09-12.ts
+++ b/scripts/review-2026-09-12.ts
@@ -1,0 +1,503 @@
+// Review of the four submissions that arrived 10-11 September 2026.
+// Three approved with edits, one declined. The two older ones in the same
+// queue (xi normality, Gromov-Hausdorff) are decided in review-2026-09-10.ts,
+// which runs first and refuses if either is no longer pending.
+//
+// ---------------------------------------------------------------------------
+// HILBERT-UMD SHARPNESS (Lorist, van Neerven; arXiv 2609.10444) - approved,
+// Lean-verified, ai-co-developed, significance 25.
+//
+// The claim: the classical quadratic comparisons between the Hilbert
+// transform constant and the UMD constant, h <~ beta^2 and beta <~ h^2, are
+// both sharp. Two explicit families of 2^n-dimensional spaces, X_n with
+// h ~ n and beta ~ sqrt(n), Y_n the reverse. The paper says "it has long been
+// an open problem whether these can be improved to linear bounds", cites
+// Burkholder's 2001 Handbook survey, and records Wenzel's summation operators
+// as earlier candidates for exactly this separation.
+//
+// Checked at the level the Lean tier requires, on the pinned commit 055d95e:
+//
+//   1. Statement. Main/PaperStatement.lean states Theorem11Bounds: the two
+//      dimensions and all eight inequalities, with n and sqrt(n) literally
+//      as in the paper and universal constants c, C. hbar and beta are
+//      abbreviations of hilbertConstant and umdConstant on the identity.
+//   2. The two constants are project definitions - Mathlib has no UMD
+//      constant - so they are the trust surface, and both were read.
+//      umdConstant is the infimum of C over ALL sigma-finite sample spaces,
+//      filtrations, L^p martingales and unimodular coefficients such that
+//      the martingale transform is bounded by C times the difference sum;
+//      hilbertConstant is the infimum of C over all C^1 compactly supported
+//      f such that a principal-value Hilbert transform exists in L^p with
+//      norm at most C times the norm of f. Those are the textbook notions.
+//      A universe-independence theorem transports beta between universes
+//      with the same coefficients.
+//   3. Counted: no sorry, no axiom declarations, no native_decide, no unsafe
+//      anywhere in the sources. tests/AxiomAudit.lean walks EVERY project
+//      declaration transitively and fails on any admission or any axiom
+//      beyond propext, Classical.choice, Quot.sound.
+//   4. Independent of the authors' machines: GitHub Actions ran the build
+//      and the audit on ubuntu and windows at the reviewed commit, both
+//      green.
+//
+// What the formalisation does not cover, and the entry says so: Corollary
+// 1.3 (every p other than 2, via extrapolation) and the exact coefficients of
+// Remark 1.2, where the Lean development proves the same growth rates with
+// different numbers. The submitter's own verification note already said
+// this, accurately.
+//
+// Dating: 1983 kept. Bourgain 1983 and Burkholder 1983 established the
+// quadratic bounds and so opened the sharpness question, the same shape as
+// dating Navier-Stokes from Leray; the 2001 survey is where it is written
+// down as a problem. posedBy now says both. The submitter had flagged this
+// exact distinction in their note.
+//
+// Significance 25, level with kalton-peck-space-hyperplanes and
+// mazya-maximal-operator-banach-space, below Stein's dimension-free Riesz
+// problem at 38: a long-standing question with its own literature (Wenzel,
+// Petermichl, Domelevo-Petermichl reduce it to a dyadic shift) inside one
+// research community.
+//
+// ---------------------------------------------------------------------------
+// ENTROPY-METHOD CEILING FOR UNION-CLOSED (Moffat) - approved, Lean-checked,
+// ai-discovered, significance 18.
+//
+// Two unconditional barrier theorems: every single-letter certificate whose
+// classes contain product laws certifies at most 1 - h(1/sqrt 2)/sqrt 2 =
+// 0.383099..., and every certificate using the i.i.d. protocol whose other
+// classes admit component hiding certifies at most 0.382885... The refined
+// ceiling sits 1.8e-4 above Liu's record 0.382709. Frankl's conjecture is
+// not claimed and the entry says so twice.
+//
+// Was the question posed? Not as a numbered problem, but it was live in
+// print: Cambie's 2022 paper (arXiv 2212.12500) says it focuses "on the
+// intuition behind this entropy approach and its boundaries" and argues the
+// constant "cannot be significantly improved" by Sawin's question; Liu 2023
+// raises "a natural question" about other couplings. Cambie solved the
+// ceiling of one specific certificate form (Sawin's, 0.3823455); nothing
+// found gives a ceiling over the whole single-letter framework. That is the
+// new content, and it is not a duplicate of anything in the catalog.
+//
+// Tier: Lean-checked, not Lean-verified, and the distinction is exactly the
+// one the tier exists for. The two ceiling theorems ARE machine-checked -
+// lean/ builds with no sorry and the standard three axioms, check.sh
+// enforces both, and the lean and verify workflows are green at HEAD - but
+// what Lean proves is a theorem about `Certifies`, the author's own
+// finite-model definition of "single-letter certificate". Whether every
+// certificate in the literature is an instance is Lemma 3.3, whose
+// maximal-correlation case is paper-only, and Gilmer's reduction is a
+// hypothesis in the development. So the artifact compiles and the statement
+// it proves is faithful to the paper's framework; the framework's fidelity
+// to the informal claim "the entropy method cannot reach 1/2" was not
+// audited here. That is lean-checked by the site's definition.
+//
+// Publication: announcement, not preprint. The README says "Not yet on arXiv
+// (endorsement pending)"; the version of record is a GitHub release. The
+// site's definition puts a repository-hosted manuscript at announcement, and
+// it flips the day arXiv accepts it. sourceUrl pinned to the v1.2 release.
+//
+// ai-discovered stands on the author's own account and logs: the lead
+// model selected the problem and found both theorems, including the
+// component-hiding idea; the human set the goal, checked, and decided what
+// to publish. Referee-round reports and the campaign log are in the repo.
+//
+// Significance 18: below the Oddtown anchor at 20, which is a named
+// question, above boppana-entropy-generalization at 8; the audience is the
+// small group that has been pushing this method since 2022, and they had
+// asked this out loud.
+//
+// ---------------------------------------------------------------------------
+// LAMBDA <= 0.1787854 (Gomila) - declined, reason no-open-question.
+//
+// The submission form took the submitter's name as the entry name, and has
+// no statement, no field and no links; but the substance is clear from the
+// repository: a computer-assisted improvement of the upper bound on the de
+// Bruijn-Newman constant from 0.2 (Platt-Trudgian, via Polymath 15) to
+// 0.1787854, not peer reviewed, with an external referee report in the repo
+// and a named expert reworking the exposition.
+//
+// That is a numeric record, not the resolution of a posed question - the
+// posed question here is Newman's conjecture Lambda = 0, which this does not
+// touch. This site tracks records of exactly this kind as Frontiers (Shannon
+// capacity of C11, prime gaps, the matrix multiplication exponent), not as
+// entries, and there is no de Bruijn-Newman frontier yet. Declined as an
+// entry with the reason spelled out and the frontier route named; whether to
+// open that frontier is the curator's decision and is flagged separately.
+//
+// ---------------------------------------------------------------------------
+// subDMQ ARITHMETIC IS TRIVIAL (GPT-6 Astra; Simonelli) - approved,
+// ai-discovered, verification downgraded to unreviewed, significance 10.
+//
+// Same submitter and same shape as signed-depth-relevance-of-subdl (reviewed
+// 24 Aug), and the same call for the same reason. The paper's author line is
+// the model, with a footnote crediting Simonelli for initiating and guiding
+// the conversation: ai-discovered stands. The question was public: Ripley's
+// slides on the restricted-quantification proposal (joint with Weber) say
+// "naive set theory in subDMQ is not known to be trivial" and that the
+// programme works "without a net: no nontriviality proofs". This answers
+// it: number-restricted induction restores contraction, and with naive
+// comprehension and Curry fixed points that is triviality.
+//
+// The downgrade. The submission says Ripley confirmed the result. The only
+// public trace is the paper's own footnote 3: "I thank Ellie Ripley for
+// confirming that the argument poses a problem for the intended programme,
+// and for feedback on an earlier draft". That is a stronger trace than the
+// subDL case - it records agreement rather than a correction - and Ripley
+// is the right person, the proposer of the system, confirming a result
+// against their own proposal. But it is still the author's report of a
+// private exchange, not the expert's own words a reader can follow; the
+// expert-verified rung's worked example is a published statement by the
+// experts themselves. Unreviewed, with the note recording exactly what the
+// footnote says, so it does not read as "nobody looked".
+//
+// Significance 10, one step above the subDL entry at 7: that one settled a
+// relevance property of a logic; this one shows a proposed foundation
+// proves everything, which forces a revision of the programme. Still a
+// community of a few dozen.
+//
+// ---------------------------------------------------------------------------
+// Pass --lint to run every local check (field limits, the form's own rules,
+// message lengths) without touching a database. Dry run by default. Pass
+// --apply to write. Production writes are the curator's to run.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+import { checkStoredEntry } from "../src/lib/field-validation";
+import { CURATOR_FIELDS, EDITABLE_FIELDS } from "../src/lib/editable";
+import { MESSAGE_MAX } from "../src/lib/messages";
+import { charLength, canonical } from "../src/lib/char-length";
+
+const APPLY = process.argv.includes("--apply");
+const LINT = process.argv.includes("--lint");
+const SPECS = [...EDITABLE_FIELDS, ...CURATOR_FIELDS];
+const LINK_LABEL_MAX = 120;
+
+const UMD_REPO = "https://github.com/elorist/UMD_Hilberttransform";
+const UMD_SHA = "055d95e55fe97988d1e94f6a5d11d126eb5e3a3d";
+const UC_REPO = "https://github.com/moffatstudio/union-closed-constant";
+
+interface Decision {
+  slug: string;
+  action: "approve" | "reject";
+  reason: string;
+  message: string;
+  edits?: Record<string, unknown>;
+  links?: { label: string; url: string; kind: string }[];
+}
+
+const DECISIONS: Decision[] = [
+  {
+    slug: "the-hilbert-transform-umd-dependence-problem",
+    action: "approve",
+    reason: "edited",
+    edits: {
+      name: "The Hilbert transform-UMD dependence problem",
+      statement:
+        "For fixed $1<p<\\infty$ and a Banach space $X$, Burkholder and Bourgain showed in 1983 that the UMD property is equivalent to boundedness of the Hilbert transform on $L^p(\\mathbb{R};X)$, with the quadratic comparisons $\\hbar_{p,X}\\lesssim\\beta_{p,X}^{2}$ and $\\beta_{p,X}\\lesssim\\hbar_{p,X}^{2}$ between the Hilbert transform constant and the UMD constant. What is the optimal dependence between $\\hbar_{p,X}$ and $\\beta_{p,X}$, uniformly over all UMD spaces $X$: can either quadratic bound be improved, in the best case to a linear one?",
+      posedBy:
+        "Implicit in Burkholder's and Bourgain's 1983 quadratic bounds; stated as an open problem in Burkholder's 2001 Handbook survey",
+      resultNote:
+        "Neither exponent can be lowered. Theorem 1.1 constructs explicit $2^{n}$-dimensional spaces $X_n$ and $Y_n$ with $\\hbar_{2,X_n}\\asymp n$, $\\beta_{2,X_n}\\asymp\\sqrt n$ and $\\beta_{2,Y_n}\\asymp n$, $\\hbar_{2,Y_n}\\asymp\\sqrt n$, with universal comparison constants, so both quadratic comparisons are sharp at $p=2$; Corollary 1.3 extends the growth rates to every fixed $1<p<\\infty$ by extrapolation, with constants depending on $p$. The spaces are built from the summation operators Wenzel had proposed as candidates for exactly this separation. The Lean formalisation covers Theorem 1.1 at $p=2$ over both real and complex scalars; the extrapolation to other $p$ and the exact coefficients of Remark 1.2 are outside it.",
+      verificationNote:
+        "Checked here on 12 September 2026 by reading the repository at commit 055d95e. Main/PaperStatement.lean states the theorem as the two dimensions and all eight inequalities, with $n$ and $\\sqrt n$ literally as in the paper and universal constants. Mathlib has no UMD constant, so the two constants are project definitions and are the trust surface; both were read. umdConstant is the infimum of $C$ over all $\\sigma$-finite sample spaces, filtrations, $L^p$ martingales and unimodular coefficients for which the martingale transform is bounded by $C$ times the difference sum, and hilbertConstant is the infimum of $C$ over all $C^1$ compactly supported $f$ admitting a principal-value Hilbert transform in $L^p$ with norm at most $C\\,\\|f\\|_p$; these are the standard notions. No sorry, no axiom declarations, no native_decide anywhere; tests/AxiomAudit.lean walks every project declaration transitively and fails on any admission or any axiom beyond propext, Classical.choice and Quot.sound. GitHub Actions ran the build and that audit on Ubuntu and Windows at the reviewed commit, both green, which puts the kernel check on machines other than the authors'. The build was not repeated here. Not formalised: Corollary 1.3 and the exact coefficients of Remark 1.2.",
+      aiRole:
+        "The paper's AI disclosure: \"The examples proving the quadratic dependencies were found in conversations with OpenAI's Astra model. All statements and proofs in the final manuscript have been reviewed by the authors and subsequently proof-checked in Lean 4 using OpenAI's Astra model.\" The repository README adds that the Lean code, documentation, scripts and tests were generated with GPT-6 Astra under human direction. Co-developed: the decisive constructions came out of conversations with the model, and two named authors reviewed and take responsibility for the manuscript.",
+      significance: 25,
+      significanceNote:
+        "A long-standing question with its own literature inside vector-valued harmonic analysis: the paper calls it a long-open problem, Burkholder's 2001 survey states it, Wenzel proposed candidate operators for the separation, and Domelevo and Petermichl reduced it to a dyadic shift. Level with the Kalton-Peck hyperplane and Maz'ya maximal-operator entries at 25, and below Stein's dimension-free Riesz transform problem at 38, which is known well beyond one community.",
+      sourceName: "arXiv 2609.10444, v1 (9 September 2026)",
+    },
+    links: [
+      {
+        kind: "lean-statement",
+        label: "PaperStatement.lean: Theorem 1.1 as formalised, at the reviewed commit",
+        url: `${UMD_REPO}/blob/${UMD_SHA}/HilbertUMD/Main/PaperStatement.lean`,
+      },
+      {
+        kind: "other",
+        label: "GitHub Actions: build and whole-project axiom audit, Ubuntu and Windows",
+        url: `${UMD_REPO}/actions`,
+      },
+    ],
+    message: [
+      "Approved and published at Lean-verified.",
+      "",
+      "What was checked rather than taken on trust: PaperStatement.lean states all eight inequalities with n and sqrt(n) as in the paper; the two constants are project definitions, since Mathlib has no UMD constant, so both were read - umdConstant quantifies over all sigma-finite sample spaces, filtrations, L^p martingales and unimodular coefficients, hilbertConstant over C^1 compactly supported tests with a principal-value transform - and they are the standard notions. No sorry or extra axiom anywhere, AxiomAudit.lean walks every declaration transitively, and the Actions runs on Ubuntu and Windows at commit 055d95e are green. I did not rebuild locally.",
+      "",
+      "Your verification note was accurate about the formalisation's scope, and the entry keeps that: Theorem 1.1 at p = 2, not Corollary 1.3, and coefficients that differ from Remark 1.2 without changing the growth rates.",
+      "",
+      "Dating: 1983 kept, and your note on it was the honest way to handle it. The quadratic bounds of Bourgain and Burkholder are what opened the sharpness question, which is the same convention this site uses for Navier-Stokes from Leray; posedBy now says that and names the 2001 Handbook survey as where it is written down as a problem.",
+      "",
+      "Significance 25, level with the Kalton-Peck and Maz'ya entries and below Stein's Riesz problem at 38. Two links added: the formal statement file at the reviewed commit, and the Actions page, so a reader can see the cross-platform audit without cloning.",
+    ].join("\n"),
+  },
+  {
+    slug: "the-ceiling-of-the-single-letter-entropy-method-for-the-union-closed-sets-conjec",
+    action: "approve",
+    reason: "edited",
+    edits: {
+      posedBy:
+        "Raised in the entropy-method literature after Gilmer (2022): Cambie (2022) studies the approach's boundaries, Liu (2023) asks whether other couplings can improve it",
+      verification: "lean-checked",
+      verificationNote:
+        "Filed at Lean-checked rather than Lean-verified, and the distinction is the one that tier exists for. The two unconditional ceiling theorems are machine-checked: the lean/ project builds with no sorry and only propext, Classical.choice and Quot.sound, check.sh enforces both, and the lean and verify workflows were green at HEAD on 10 September. What Lean proves, though, is a theorem about Certifies, the author's own finite-model definition of a single-letter certificate. Whether every certificate in the literature is an instance is Lemma 3.3, whose maximal-correlation case is paper-only, and Gilmer's reduction from union-closed families to the certificate is a hypothesis in the development rather than a theorem. So the artifact compiles and proves what the paper's framework says; the framework's fidelity to the informal claim that the entropy method cannot reach $1/2$ was not audited here. The computer-assisted constant $0.38284$ is conditional on two numerically verified hypotheses of the same kind as those behind Liu's record, and is not in the formalisation. Not peer reviewed and not checked by a named expert; four rounds of referee reports were produced by the author's own model agents and are in the repository.",
+      publication: "announcement",
+      significance: 18,
+      significanceNote:
+        "Not a numbered question, but one the people pushing this method had asked in print: Cambie's 2022 paper studies the approach's boundaries and argues Sawin's question cannot move the constant far, and Liu 2023 asks whether other couplings can. Nothing found gives a ceiling over the whole single-letter framework, which is what this settles. Below the Oddtown anchor at 20, a named question, and above the Boppana entropy generalisation at 8; the readership is the small group that has worked this method since 2022, and Frankl's conjecture itself is untouched.",
+      sourceUrl: `${UC_REPO}/releases/tag/v1.2`,
+      sourceName:
+        "GitHub release v1.2, the stated version of record: paper, code, logs, referee reports and Lean",
+    },
+    links: [
+      {
+        kind: "paper",
+        label: "The paper, 31 pages with the Lean appendices, at v1.2",
+        url: `${UC_REPO}/blob/v1.2/paper/paper.pdf`,
+      },
+      {
+        kind: "lean-proof",
+        label: "lean/: Theorems 3.1 and 3.4 machine-checked, with check.sh",
+        url: `${UC_REPO}/tree/v1.2/lean`,
+      },
+      {
+        kind: "problem-record",
+        label: "Cambie 2022, which studies the entropy approach's boundaries",
+        url: "https://arxiv.org/abs/2212.12500",
+      },
+    ],
+    message: [
+      "Approved and published, as the ceiling theorems, exactly as you framed it - not as a partial on Frankl. The two ceilings are the result; the constant is context, and the entry keeps that order.",
+      "",
+      "Three changes, all explained on the entry.",
+      "",
+      "Verification is Lean-checked rather than Unreviewed, which is a step up, but not Lean-verified, which you did not claim. The two theorems are machine-checked - no sorry, the standard three axioms, check.sh enforcing both, CI green at HEAD - and that is real. What Lean proves is a theorem about Certifies, your own definition of a single-letter certificate; whether every certificate in the literature is an instance is Lemma 3.3, part of which is paper-only, and Gilmer's reduction is a hypothesis in the development. That is the definition of Lean-checked on this site: the artifact compiles and matches the paper's framework, and the framework's match to the informal claim was not audited here.",
+      "",
+      "Publication is Announcement, not Preprint. Your README says it: not yet on arXiv, endorsement pending. The site's definition puts a repository-hosted manuscript there, and it flips to Preprint the day the arXiv posting exists - tell me and it changes. The source URL is pinned to the v1.2 release you named as the version of record.",
+      "",
+      "posedBy is expanded from \"implicit\" to the two places it was actually raised in print: Cambie 2022 on the approach's boundaries, Liu 2023 on whether other couplings help. Cambie's paper is linked as the problem record. That is also why this is not a duplicate: Cambie solved the ceiling of one certificate form, Sawin's; nothing found gives one over the whole framework.",
+      "",
+      "Significance 18: below the Oddtown anchor at 20, since nobody numbered this question, and above the Boppana entropy generalisation at 8.",
+      "",
+      "The repository is a model of how to make a claim checkable: the referee rounds, the re-certification from the written statement alone, the withdrawn claims left in place and marked.",
+    ].join("\n"),
+  },
+  {
+    slug: "jude-gomila",
+    action: "reject",
+    reason: "no-open-question",
+    message: [
+      "Thanks for sending this, and for the care in the repository: the sealed manifests, the fail-closed certificates, the external referee report and the open review questions are all more than most submissions here carry. This is declined as an entry, for a reason about scope rather than about the work.",
+      "",
+      "The site's inclusion test is a precisely stated open question whose answer is now a proved or disproved theorem. Lambda <= 0.1787854 is a new upper bound - an improvement of a record from 0.2 - and the posed question in this area is Newman's conjecture that Lambda = 0, which this does not settle. Records of exactly this kind are tracked here as Frontiers, not as entries: the Shannon capacity of C11, prime gaps, the matrix multiplication exponent each have a staircase page with one row per improvement and a source pinned for each. There is no de Bruijn-Newman frontier yet. Opening one is a curator decision and I have flagged it; if it opens, this bound would be its most recent row, marked as it is marked in your own README - computer-assisted, not yet peer reviewed - with the Platt-Trudgian 0.2 and Polymath's 0.22 above it.",
+      "",
+      "Two things worth knowing if it comes to that. A frontier row needs a pinned source: a release tag or a commit rather than a moving branch, which your sealed SHA256SUMS already make natural. And the entry form took your name as the entry name, and had no statement or field, so nothing from this submission was reusable as text; that is a form usability problem on our side as much as anything.",
+      "",
+      "Nothing here is a judgement on the mathematics, which nobody at this site is placed to make.",
+    ].join("\n"),
+  },
+  {
+    slug: "nontriviality-of-number-restricted-arithmetic-over-subdmq",
+    action: "approve",
+    reason: "downgraded",
+    edits: {
+      shortName: "subDMQ arithmetic is trivial",
+      statement:
+        "Weber's programme of paraconsistent mathematics keeps unrestricted comprehension and revises the logic of inference so that contradictions do not make every statement provable. Ripley and Weber's 2026 proposal restricts induction to numbers as part of a strategy for blocking paradox, and Ripley's presentation of it records that the resulting theory is not known to be trivial, the programme working \"without a net: no nontriviality proofs\". Is number-restricted arithmetic over subDMQ nontrivial: does it, together with naive comprehension and induction over the combined language, avoid proving everything?",
+      model: "GPT-6 Astra",
+      modelMaker: "OpenAI",
+      verification: "unreviewed",
+      verificationNote:
+        "Filed as Unreviewed rather than the submitted Expert-verified, for the same reason as this submitter's earlier subDL entry, and the trace is stronger this time. The paper's footnote 3 reads: \"I thank Ellie Ripley for confirming that the argument poses a problem for the intended programme, and for feedback on an earlier draft that helped to clarify and shorten this note.\" Ripley is exactly the right person - the proposer of subDMQ and of the restricted-induction strategy, confirming a result against their own proposal - and that footnote records agreement, not merely a correction. But it is the author's report of a private exchange, not the expert's own words a reader can follow to the source, and the Expert-verified rung's worked example is a published statement by the experts themselves. A public statement from Ripley would lift it. The paper supplies finite Hilbert-style proof certificates replayed by a custom Python checker and Isabelle replay scripts that the submitter reports have not been executed; neither was run here. This site checked the surrounding facts, not the derivations: Ripley's slides state the question as open, and the paper's source comparison pins Ripley's formalisation to the commit it examined.",
+      aiRole:
+        "The paper's author line is \"GPT-6 Astra (context 1e44c278f25b)\", dated 10 September 2026, with a footnote: \"Ryan Simonelli initiated and guided the research conversation that produced this note. The argument emerged from repeated unsuccessful attempts, at his prompting, to find an elegant sequent calculus with syntactic cut elimination for Ripley's reconstruction of Weber's mathematics.\" The submitter adds that after those attempts failed, the model instead established that the intended theory is trivial, and produced the proof constructions, the manuscript, the proof certificates and the checking code; Simonelli directed the investigation and assessed the outputs. Discovered rather than co-developed on that record: the model is credited as the author, and the human role was direction and assessment.",
+      significance: 10,
+      significanceNote:
+        "One step above this submitter's subDL entry at 7. That one settled a relevance property of a logic; this shows a proposed foundation proves everything once number-restricted induction and naive comprehension are combined, which forces a revision of the programme it was meant to support. The question was stated as open by the proposers. The community is the few dozen people working in paraconsistent mathematics, which is what keeps it at the level of a typical numbered Erdos problem rather than above it.",
+    },
+    message: [
+      "Approved and published. Verification goes from Expert-verified to Unreviewed, same as with your subDL entry, and the reasoning is spelled out on the entry because the call is closer this time.",
+      "",
+      "Footnote 3 of the paper is a genuinely stronger trace than the subDL acknowledgment was: Ripley, the proposer of the system, confirming that the argument poses a problem for the intended programme is agreement against their own interest, not a correction of a draft. But it is still your report of a private exchange rather than Ripley's own words a reader can follow to the source, and the Expert-verified rung needs the latter. If Ripley says it anywhere public - a note, a slide, a line in the repository - send the link and the tier changes.",
+      "",
+      "Other edits: the statement now poses the question rather than answering it in its own last sentence, with Ripley's slides quoted for the \"not known to be trivial\" framing; the short name is \"subDMQ arithmetic is trivial\"; model and maker are filled in as GPT-6 Astra and OpenAI. AI role stays Discovered, on the author line. Significance 10, one step above the subDL entry at 7, for the reason you gave: this forces a revision of the programme rather than settling a property inside it.",
+      "",
+      "The Isabelle replay scripts you said were not executed were not executed here either; the note says so.",
+    ].join("\n"),
+  },
+];
+
+/// The serverless cluster refuses the first connection after idling; every
+/// older script retries and the first production run of this one did not.
+async function connectWithRetry(prisma: {
+  $queryRawUnsafe: <T>(q: string) => Promise<T>;
+}): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+function lint(): number {
+  let bad = 0;
+  const limit = new Map<string, number>();
+  for (const s of SPECS) if (s.maxLength) limit.set(s.key, s.maxLength);
+  for (const d of DECISIONS) {
+    console.log(
+      `${d.action === "reject" ? "DECLINE" : "APPROVE"}  ${d.slug.slice(0, 64)}`,
+    );
+    const mlen = charLength(canonical(d.message));
+    console.log(
+      `  message : ${mlen}/${MESSAGE_MAX}${mlen > MESSAGE_MAX ? "  OVER" : ""}`,
+    );
+    if (mlen > MESSAGE_MAX) bad++;
+    for (const [k, v] of Object.entries(d.edits ?? {})) {
+      if (typeof v === "string") {
+        const n = charLength(canonical(v));
+        const lim = limit.get(k);
+        const over = lim !== undefined && n > lim;
+        console.log(`  ${k.padEnd(17)}: ${n}${lim ? `/${lim}` : ""}${over ? "  OVER" : ""}`);
+        if (over) bad++;
+      } else console.log(`  ${k.padEnd(17)}: ${JSON.stringify(v)}`);
+    }
+    for (const l of d.links ?? []) {
+      const n = l.label.length;
+      console.log(`  link (${l.kind}) ${n}/${LINK_LABEL_MAX}: ${l.label}`);
+      if (n > LINK_LABEL_MAX) bad++;
+    }
+    // The form's own rules on the edits alone; the merged link check needs
+    // the stored links and runs in the dry run.
+    const v = checkStoredEntry({ specs: SPECS, fields: d.edits ?? {} });
+    for (const x of v) console.log(`  RULE: ${x.field}: ${x.problem}`);
+    bad += v.length;
+    console.log();
+  }
+  return bad;
+}
+
+async function main() {
+  const localBad = lint();
+  if (LINT) {
+    console.log(localBad ? `${localBad} local violation(s)` : "local checks ok");
+    process.exitCode = localBad ? 1 : 0;
+    return;
+  }
+  if (localBad) throw new Error(`${localBad} local violation(s) - nothing written`);
+
+  const prisma = guardedPrisma();
+  try {
+    const db = await connectWithRetry(prisma);
+    console.log(`database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`);
+
+    const curator = await prisma.user.findFirst({
+      where: { pseudonym: "Rasmus Lindahl" },
+      select: { id: true, pseudonym: true },
+    });
+
+    let bad = 0;
+    for (const d of DECISIONS) {
+      const cur = await prisma.problem.findUnique({
+        where: { slug: d.slug },
+        select: {
+          id: true,
+          status: true,
+          name: true,
+          sourceUrl: true,
+          submittedById: true,
+          links: { select: { label: true, url: true } },
+        },
+      });
+      if (!cur) throw new Error(`not found on ${db}: ${d.slug}`);
+      if (cur.status !== "pending")
+        throw new Error(`${d.slug} is ${cur.status}, not pending`);
+      const merged = [...cur.links, ...(d.links ?? [])];
+      const v = checkStoredEntry({
+        specs: SPECS,
+        fields: d.edits ?? {},
+        links: merged,
+        sourceUrl:
+          ((d.edits?.sourceUrl as string | undefined) ?? cur.sourceUrl) || null,
+      });
+      console.log(
+        `${d.action.toUpperCase().padEnd(7)}  ${cur.name.slice(0, 60)}  -> merged check: ${v.length ? "FAILED" : "ok"}`,
+      );
+      for (const x of v) console.log(`    - ${x.field}: ${x.problem}`);
+      bad += v.length;
+      if (!cur.submittedById) console.log("  NOTE: no submitter, no message sent");
+    }
+    if (bad) throw new Error(`${bad} violation(s) - nothing written`);
+
+    if (!APPLY) {
+      console.log("\nDRY RUN - pass --apply to write");
+      return;
+    }
+    if (!curator) throw new Error("curator not found on this database");
+
+    // One statement at a time on the guarded client rather than inside
+    // $transaction, so the form's rules run on every write. Re-running after
+    // a partial failure is safe: the pending check above refuses an entry
+    // that has already been decided.
+    for (const d of DECISIONS) {
+      const cur = await prisma.problem.findUnique({
+        where: { slug: d.slug },
+        select: { id: true, submittedById: true, _count: { select: { links: true } } },
+      });
+      if (!cur) throw new Error(`vanished: ${d.slug}`);
+      const n = cur._count.links;
+
+      await prisma.problem.update({
+        where: { id: cur.id },
+        data: {
+          ...(d.edits ?? {}),
+          ...(d.links?.length
+            ? { links: { create: d.links.map((l, i) => ({ ...l, position: n + i })) } }
+            : {}),
+          status: d.action === "approve" ? "published" : "rejected",
+          reviewedAt: new Date(),
+          reviewMessage: d.message,
+          reviewReason: d.reason,
+        } as never,
+      });
+      console.log(`updated: ${d.slug}`);
+
+      if (cur.submittedById) {
+        await prisma.directMessage.create({
+          data: {
+            userId: cur.submittedById,
+            senderId: curator.id,
+            senderName: curator.pseudonym,
+            kind: "decision",
+            reason: d.reason,
+            body: d.message.slice(0, MESSAGE_MAX),
+            problemId: cur.id,
+          },
+        });
+        console.log(`messaged: ${d.slug}`);
+      }
+
+      await prisma.problemActivity.create({
+        data: {
+          problemId: cur.id,
+          userId: curator.id,
+          userName: curator.pseudonym,
+          type: d.action === "approve" ? "approved" : "rejected",
+        },
+      });
+    }
+
+    console.log("\nAPPLIED. New entries render on first request; the lists and");
+    console.log("stats lag by up to an hour, or until a deploy.");
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main();

--- a/scripts/unblock-entries-2026-09-10.ts
+++ b/scripts/unblock-entries-2026-09-10.ts
@@ -1,0 +1,257 @@
+// Frees the published entries that cannot be saved through the edit form.
+//
+// The form validates every field it posts, including ones the editor never
+// touched, so a single bad stored value made an entry permanently
+// uneditable: you opened it to fix a typo and got an error about a link you
+// had not opened. Two entries were in that state outright (a duplicated
+// link, which parseLinks rejects whatever else you change), and eleven more
+// carried a link repeating their primary source, which blocks any edit to
+// the links and is refused on submission. All thirteen violations are fixed
+// here.
+//
+// Two things fix it and both are needed. The code fix, in
+// src/app/actions/update-problem.ts, skips untouched fields before
+// validating them, so stale data can no longer block an unrelated edit. This
+// script fixes the data, so the offending values stop existing at all.
+//
+// Every violation here is a redundant link - one that repeats the entry's own
+// primary source, or another link on the same entry. Deleting it removes no
+// information: the document is still cited, once, where it belongs. That is
+// why this is safe to do in bulk, and it is the only class of violation the
+// catalog turned out to have; lengths, choices, URLs, dates and required
+// fields all came back clean across 706 published entries.
+//
+// `sameDocument` is what makes these invisible by eye: it normalises tracking
+// parameters and fragments, so ".../navierstokes.pdf?utm_source=chatgpt.com"
+// and ".../navierstokes.pdf" are one document. Nine of the eleven look like
+// distinct URLs in the admin UI.
+//
+// The check itself comes from src/lib/field-validation.ts - the same module
+// the form uses - rather than being reimplemented here, and the writes go
+// through scripts/lib/guarded-prisma.ts, which runs that check again on the
+// merged result before touching the database. That is the point of the
+// exercise: a script that writes entry data runs the form's rules first, and
+// cannot skip them by forgetting.
+//
+// Dry run by default. Pass --apply to write. Production writes are the
+// curator's to run.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+import { checkStoredEntry } from "../src/lib/field-validation";
+import {
+  EDITABLE_FIELDS,
+  CURATOR_FIELDS,
+  sameDocument,
+} from "../src/lib/editable";
+
+const prisma = guardedPrisma();
+const APPLY = process.argv.includes("--apply");
+const SPECS = [...EDITABLE_FIELDS, ...CURATOR_FIELDS];
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+interface Link {
+  id: string;
+  label: string;
+  url: string;
+  position: number;
+}
+
+/// What to do with one entry's links so the set passes.
+///
+/// Naively keeping the first of each duplicate throws away information. Both
+/// real cases proved it: on prime-gaps-at-most-186 the LATER copy carried the
+/// better label ("Challenge.lean, the statements the comparator checks"
+/// against a bare "Challenge.lean"), and on the Navier-Stokes entry the later
+/// copy had the cleaner URL - the earlier one still had a
+/// "?utm_source=chatgpt.com" tracking parameter on it.
+///
+/// So: among links pointing at one document, keep the shortest URL (the
+/// canonical form, since sameDocument has already normalised fragments and
+/// tracking parameters away) and the longest label (the most descriptive).
+/// Links that merely repeat the entry's primary source are dropped outright -
+/// the document is still cited, as the source.
+function planLinks(
+  links: Link[],
+  sourceUrl: string | null,
+): { drop: Link[]; relabel: { id: string; label: string; url: string }[] } {
+  const drop: Link[] = [];
+  const relabel: { id: string; label: string; url: string }[] = [];
+
+  const rest = links.filter((l) => {
+    if (sourceUrl && sameDocument(l.url, sourceUrl)) {
+      drop.push(l);
+      return false;
+    }
+    return true;
+  });
+
+  const groups: Link[][] = [];
+  for (const l of rest) {
+    const g = groups.find((grp) => sameDocument(grp[0].url, l.url));
+    if (g) g.push(l);
+    else groups.push([l]);
+  }
+
+  for (const g of groups) {
+    if (g.length === 1) continue;
+    // Keep the earliest row so position order is preserved, but give it the
+    // best label and URL the group had.
+    const keep = g[0];
+    const bestLabel = g.reduce(
+      (a, b) => (b.label.length > a.length ? b.label : a),
+      keep.label,
+    );
+    const bestUrl = g.reduce(
+      (a, b) => (b.url.length < a.length ? b.url : a),
+      keep.url,
+    );
+    if (bestLabel !== keep.label || bestUrl !== keep.url)
+      relabel.push({ id: keep.id, label: bestLabel, url: bestUrl });
+    for (const l of g.slice(1)) drop.push(l);
+  }
+  return { drop, relabel };
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(
+    `database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`,
+  );
+
+  const rows = await prisma.$queryRawUnsafe<
+    {
+      slug: string;
+      sourceUrl: string | null;
+      id: string;
+      label: string;
+      url: string;
+      position: number;
+    }[]
+  >(
+    `SELECT p.slug, p."sourceUrl", l.id, l.label, l.url, l.position
+       FROM "Problem" p JOIN "ProblemLink" l ON l."problemId" = p.id
+      WHERE p.status = 'published'
+      ORDER BY p.slug, l.position`,
+  );
+
+  const byEntry = new Map<
+    string,
+    { sourceUrl: string | null; links: Link[] }
+  >();
+  for (const r of rows) {
+    const e = byEntry.get(r.slug) ?? { sourceUrl: r.sourceUrl, links: [] };
+    e.links.push({
+      id: r.id,
+      label: r.label,
+      url: r.url,
+      position: r.position,
+    });
+    byEntry.set(r.slug, e);
+  }
+
+  const plan: {
+    slug: string;
+    drop: Link[];
+    relabel: { id: string; label: string; url: string }[];
+  }[] = [];
+  for (const [slug, e] of byEntry) {
+    const before = checkStoredEntry({
+      specs: SPECS,
+      links: e.links,
+      sourceUrl: e.sourceUrl,
+    });
+    if (before.length === 0) continue;
+
+    const { drop, relabel } = planLinks(e.links, e.sourceUrl);
+    const after = checkStoredEntry({
+      specs: SPECS,
+      links: e.links.filter((l) => !drop.some((d) => d.id === l.id)),
+      sourceUrl: e.sourceUrl,
+    });
+
+    console.log(`${slug}`);
+    for (const v of before) console.log(`    was: ${v.problem}`);
+    for (const d of drop)
+      console.log(`    drop link: "${d.label.slice(0, 58)}"`);
+    for (const r of relabel)
+      console.log(`    keep, improved: "${r.label.slice(0, 58)}"
+        ${r.url}`);
+    if (after.length) {
+      // Deleting redundant links did not make the entry valid, so something
+      // else is wrong and a blind delete would not fix it. Refuse rather
+      // than half-fix.
+      for (const v of after) console.log(`    STILL BAD: ${v.problem}`);
+      throw new Error(`${slug} is not fixed by dropping redundant links`);
+    }
+    plan.push({ slug, drop, relabel });
+  }
+
+  console.log(
+    `\nentries blocked: ${plan.length}   links to delete: ${plan.reduce((n, p) => n + p.drop.length, 0)}`,
+  );
+
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+
+  for (const p of plan) {
+    // Delete first. The guarded client validates the merged link set on
+    // every update, so relabelling the kept link while its duplicate still
+    // exists would be refused - correctly.
+    await prisma.$executeRawUnsafe(
+      `DELETE FROM "ProblemLink" WHERE id = ANY($1::uuid[])`,
+      p.drop.map((d) => d.id),
+    );
+    for (const r of p.relabel) {
+      await prisma.problemLink.update({
+        where: { id: r.id },
+        data: { label: r.label, url: r.url },
+      });
+    }
+    console.log(
+      `fixed: ${p.slug} (-${p.drop.length}${p.relabel.length ? `, ${p.relabel.length} improved` : ""})`,
+    );
+  }
+
+  // Prove it, rather than assume it: re-read and re-check every entry.
+  const after = await prisma.$queryRawUnsafe<
+    { slug: string; sourceUrl: string | null; label: string; url: string }[]
+  >(
+    `SELECT p.slug, p."sourceUrl", l.label, l.url
+       FROM "Problem" p JOIN "ProblemLink" l ON l."problemId" = p.id
+      WHERE p.status = 'published' ORDER BY p.slug, l.position`,
+  );
+  const check = new Map<string, { sourceUrl: string | null; links: Link[] }>();
+  for (const r of after) {
+    const e = check.get(r.slug) ?? { sourceUrl: r.sourceUrl, links: [] };
+    e.links.push({ id: "", label: r.label, url: r.url, position: 0 });
+    check.set(r.slug, e);
+  }
+  let bad = 0;
+  for (const [, e] of check)
+    bad += checkStoredEntry({
+      specs: SPECS,
+      links: e.links,
+      sourceUrl: e.sourceUrl,
+    }).length;
+  console.log(`\nAPPLIED. Remaining violations across the catalog: ${bad}`);
+}
+
+main().finally(() => prisma.$disconnect());

--- a/scripts/verify-simonelli-2026-09-12.ts
+++ b/scripts/verify-simonelli-2026-09-12.ts
@@ -1,0 +1,85 @@
+// Finishes the one write that contact-replies-2026-09-12.ts did not land.
+//
+// That script sent all nine in-app replies and marked all eighteen contact
+// messages handled, then died setting this flag: its verification step looked
+// the account up through the SiteMessage, and `userFor` only matches rows
+// with status 'open' - which the loop three lines earlier had just changed to
+// 'handled'. A write ordered after the write that invalidates its own lookup.
+// The bug is fixed there; re-running that script is not the way to finish
+// this, because it would send all nine replies a second time.
+//
+// So: this sets the one remaining flag, and nothing else.
+//
+// The identity, checked on 12 September 2026 and checkable by anyone from
+// both ends: ryansimonelli.com/autonomous-philosophy.html links to
+// vibemathed.com/problem/signed-depth-relevance-of-subdl, and that entry was
+// submitted by this account. A page the person controls pointing at an entry
+// the account submitted is the strongest evidence the badge can rest on,
+// because neither half can be forged without the other.
+//
+// The account is addressed by id rather than by pseudonym or by the contact
+// row, for the reason the parent script learned twice: pseudonyms change
+// (theabbie is now SilentBison701) and the contact row is no longer open.
+//
+// Dry run by default. Pass --apply to write.
+
+import { guardedPrisma } from "./lib/guarded-prisma";
+
+const prisma = guardedPrisma();
+const APPLY = process.argv.includes("--apply");
+
+const EMAIL = "ryanasimonelli@gmail.com";
+const NOTE =
+  "Ryan Simonelli. Two-way link checked 12 September 2026: ryansimonelli.com/autonomous-philosophy.html links to vibemathed.com/problem/signed-depth-relevance-of-subdl, and that entry was submitted by this account.";
+
+async function connectWithRetry(): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const [{ db }] = await prisma.$queryRawUnsafe<{ db: string }[]>(
+        "SELECT current_database() AS db",
+      );
+      return db;
+    } catch (e) {
+      lastError = e;
+      console.log(`connection attempt ${attempt} failed; retrying in 5s`);
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const db = await connectWithRetry();
+  console.log(`database: ${db}${db === "vibemathed" ? "  (PRODUCTION)" : ""}\n`);
+
+  const users = await prisma.user.findMany({
+    where: { email: EMAIL },
+    select: { id: true, email: true, pseudonym: true, verified: true, verifiedNote: true },
+  });
+  if (users.length !== 1)
+    throw new Error(`${EMAIL}: matched ${users.length} accounts, expected 1`);
+  const u = users[0];
+
+  console.log(`account   : ${u.pseudonym ?? "(no pseudonym)"}  <${u.email}>`);
+  console.log(`verified  : ${u.verified} -> true`);
+  console.log(`note      : ${u.verifiedNote ?? "(none)"}`);
+  console.log(`         -> ${NOTE}`);
+
+  if (u.verified) {
+    console.log("\nAlready verified - nothing to do.");
+    return;
+  }
+  if (!APPLY) {
+    console.log("\nDRY RUN - pass --apply to write");
+    return;
+  }
+
+  await prisma.user.update({
+    where: { id: u.id },
+    data: { verified: true, verifiedNote: NOTE },
+  });
+  console.log("\nAPPLIED. The profile shows the badge on its next render.");
+}
+
+main().finally(() => prisma.$disconnect());

--- a/src/app/actions/update-problem.ts
+++ b/src/app/actions/update-problem.ts
@@ -3,98 +3,20 @@
 import { updateTag } from "next/cache";
 import { auth } from "@/auth";
 import { canReview } from "@/lib/curators";
-import { canonical, charLength } from "@/lib/char-length";
 import { prisma } from "@/lib/prisma";
 import {
   EDITABLE_FIELDS,
   CURATOR_FIELDS,
-  isHttpUrl,
-  isValidSolveDate,
-  parseLinks,
   sameDocument,
   type EditableValues,
-  type FieldSpec,
 } from "@/lib/editable";
-import { parseRelations, relationKind, type RelationRef } from "@/lib/relation-kinds";
+import { canonical } from "@/lib/char-length";
+import { relationKind, type RelationRef } from "@/lib/relation-kinds";
+import { parseField, type Parsed } from "@/lib/field-validation";
 import type { LinkRef } from "@/lib/problems";
 
 export type UpdateResult =
-  | { ok: true; changed: number }
-  | { ok: false; error: string };
-
-/// The database value a form string maps to.
-type Parsed = string | number | string[] | LinkRef[] | RelationRef[] | null;
-
-function parseField(
-  spec: FieldSpec,
-  raw: string,
-  ownSlug: string,
-): { ok: true; value: Parsed } | { ok: false; error: string } {
-  // NFC as well as trim, so the value that gets counted below is the value
-  // that gets stored. Without it a decomposed paste is measured one way and
-  // written another, and two spellings of one visible name sit in the
-  // catalog as different strings.
-  const v = canonical(raw.trim());
-
-  if (v === "") {
-    if (spec.required) return { ok: false, error: `${spec.label} cannot be empty.` };
-    const emptyArray = spec.kind === "list" || spec.kind === "links" || spec.kind === "relations";
-    return { ok: true, value: emptyArray ? [] : null };
-  }
-
-  // charLength, not v.length: see src/lib/char-length.ts. Counting UTF-16
-  // units refused notes the author had correctly counted as under the cap,
-  // because blackboard bold and friends cost two units each.
-  if (spec.maxLength && charLength(v) > spec.maxLength) {
-    return {
-      ok: false,
-      error: `${spec.label} is too long: ${charLength(v)} characters, max ${spec.maxLength}.`,
-    };
-  }
-
-  if (spec.plainText && v.includes("$")) {
-    return {
-      ok: false,
-      error: `${spec.label} is plain text: write math in ASCII (L^p, n=5) rather than $...$, which renders as raw LaTeX in tabs, feeds and search.`,
-    };
-  }
-
-  switch (spec.kind) {
-    case "choice": {
-      const allowed = (spec.options ?? []).map((o) => o.value);
-      if (!allowed.includes(v)) {
-        return { ok: false, error: `${spec.label} is not a valid option.` };
-      }
-      return { ok: true, value: v };
-    }
-    case "number": {
-      if (!/^\d+$/.test(v)) return { ok: false, error: `${spec.label} must be a whole number.` };
-      const n = Number(v);
-      if (spec.key === "yearPosed" && (n < 1000 || n > 3000)) {
-        return { ok: false, error: "Year posed must be a four-digit year." };
-      }
-      return { ok: true, value: n };
-    }
-    case "url":
-      if (!isHttpUrl(v)) return { ok: false, error: `${spec.label} must start with http:// or https://.` };
-      return { ok: true, value: v };
-    case "list":
-      return {
-        ok: true,
-        value: v.split(",").map((s) => s.trim()).filter(Boolean),
-      };
-    case "links":
-      return parseLinks(v);
-    case "relations":
-      return parseRelations(v, ownSlug);
-    case "text":
-    case "textarea":
-      if (spec.key === "solveDate" && !isValidSolveDate(v)) {
-        return { ok: false, error: "Solve date must be YYYY, YYYY-MM or YYYY-MM-DD." };
-      }
-      return { ok: true, value: v };
-  }
-}
+  { ok: true; changed: number } | { ok: false; error: string };
 
 /// Renders a stored value as the string shown in the changelog diff.
 function display(value: unknown): string | null {
@@ -173,9 +95,17 @@ export async function updateProblem(
       citationsUrl: true,
       sourceUrl: true,
       sourceName: true,
-      links: { select: { label: true, url: true, kind: true }, orderBy: { position: "asc" } },
+      links: {
+        select: { label: true, url: true, kind: true },
+        orderBy: { position: "asc" },
+      },
       relationsFrom: {
-        select: { toId: true, kind: true, note: true, to: { select: { slug: true } } },
+        select: {
+          toId: true,
+          kind: true,
+          note: true,
+          to: { select: { slug: true } },
+        },
         orderBy: { position: "asc" },
       },
     },
@@ -193,7 +123,11 @@ export async function updateProblem(
   }));
 
   const data: Record<string, Parsed> = {};
-  const changes: { field: string; oldValue: string | null; newValue: string | null }[] = [];
+  const changes: {
+    field: string;
+    oldValue: string | null;
+    newValue: string | null;
+  }[] = [];
   // Links and relations live in their own tables, so they are collected
   // separately and rewritten wholesale rather than assigned onto the row.
   let nextLinks: LinkRef[] | null = null;
@@ -207,13 +141,30 @@ export async function updateProblem(
     const raw = values[spec.key];
     if (raw === undefined) continue;
 
-    const parsed = parseField(spec, raw, slug);
-    if (!parsed.ok) return { ok: false, error: parsed.error };
-
     const before =
       spec.kind === "relations"
         ? display(currentRelations)
         : display(current[spec.key as keyof typeof current]);
+
+    // Untouched fields are skipped BEFORE they are validated, not after.
+    //
+    // The other order made an entry unsavable whenever any one of its stored
+    // values would fail today's rules: the form posts every field, so an
+    // editor fixing a typo in the title got "Extra links: that link is
+    // already the entry's primary source" about a link they had never
+    // opened, and no edit to that entry could ever succeed. Two published
+    // entries were in that state on 10 September 2026, and eleven more were
+    // one link-edit away from it.
+    //
+    // Comparing the submitted string against the stored one first means a
+    // field nobody changed cannot block the save, while any attempt to
+    // CHANGE a bad value still has to make it valid - which is the rule the
+    // limits are actually there for.
+    if (canonical(raw.trim()) === (before ?? "")) continue;
+
+    const parsed = parseField(spec, raw, slug);
+    if (!parsed.ok) return { ok: false, error: parsed.error };
+
     const after = display(parsed.value);
     if (before === after) continue;
 
@@ -237,8 +188,11 @@ export async function updateProblem(
   // whether they now collide. Enforced only when the edit touched one of the
   // two, so an unrelated change to an entry is never blocked by it.
   if (nextLinks !== null || data.sourceUrl !== undefined) {
-    const primaryUrl = (data.sourceUrl as string | undefined) ?? current.sourceUrl;
-    const clash = (nextLinks ?? current.links).find((l) => sameDocument(l.url, primaryUrl));
+    const primaryUrl =
+      (data.sourceUrl as string | undefined) ?? current.sourceUrl;
+    const clash = (nextLinks ?? current.links).find((l) =>
+      sameDocument(l.url, primaryUrl),
+    );
     if (clash) {
       return {
         ok: false,
@@ -252,17 +206,25 @@ export async function updateProblem(
   // Relations need the database to finish validating: the target must be a
   // real published entry, and the same edge must not already exist drawn from
   // the other side. Resolved here into the ids the write needs.
-  let relationRows: { toId: string; kind: string; note: string; position: number }[] | null = null;
+  let relationRows:
+    { toId: string; kind: string; note: string; position: number }[] | null =
+    null;
   const affectedSlugs: string[] = [];
   if (nextRelations !== null) {
     const targets = await prisma.problem.findMany({
-      where: { slug: { in: nextRelations.map((r) => r.to) }, status: "published" },
+      where: {
+        slug: { in: nextRelations.map((r) => r.to) },
+        status: "published",
+      },
       select: { id: true, slug: true },
     });
     const bySlug = new Map(targets.map((t) => [t.slug, t.id]));
     for (const r of nextRelations) {
       if (!bySlug.has(r.to)) {
-        return { ok: false, error: `No published entry with the slug "${r.to}".` };
+        return {
+          ok: false,
+          error: `No published entry with the slug "${r.to}".`,
+        };
       }
     }
     // A symmetric edge drawn from the other entry is the SAME relation, and a
@@ -277,7 +239,10 @@ export async function updateProblem(
       },
       select: { kind: true, from: { select: { slug: true, name: true } } },
     });
-    if (reverse && nextRelations.some((r) => r.kind === reverse.kind && bySlug.get(r.to))) {
+    if (
+      reverse &&
+      nextRelations.some((r) => r.kind === reverse.kind && bySlug.get(r.to))
+    ) {
       const collides = nextRelations.find(
         (r) => r.kind === reverse.kind && r.to === reverse.from.slug,
       );
@@ -301,7 +266,10 @@ export async function updateProblem(
     // must drop: the new targets, and any old targets an edge was removed
     // from.
     affectedSlugs.push(
-      ...new Set([...nextRelations.map((r) => r.to), ...currentRelations.map((r) => r.to)]),
+      ...new Set([
+        ...nextRelations.map((r) => r.to),
+        ...currentRelations.map((r) => r.to),
+      ]),
     );
   }
 
@@ -311,7 +279,10 @@ export async function updateProblem(
   // have to come with their justification. Requiring the note to change in
   // the same edit means the changelog always records WHY it moved.
   const movedTier = changes.some(
-    (c) => c.field === "Verification" || c.field === "Status" || c.field === "Publication",
+    (c) =>
+      c.field === "Verification" ||
+      c.field === "Status" ||
+      c.field === "Publication",
   );
   const explained = changes.some((c) => c.field === "Verification note");
   if (movedTier && !explained) {
@@ -362,7 +333,10 @@ export async function updateProblem(
     ]);
   } catch (error) {
     console.error("updateProblem failed", error);
-    return { ok: false, error: "Could not save your changes. Please try again." };
+    return {
+      ok: false,
+      error: "Could not save your changes. Please try again.",
+    };
   }
 
   updateTag("problems");

--- a/src/lib/field-validation.test.ts
+++ b/src/lib/field-validation.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { checkStoredEntry, parseField } from "@/lib/field-validation";
+import { EDITABLE_FIELDS, CURATOR_FIELDS } from "@/lib/editable";
+
+// These rules were unreachable from a test until the validator moved out of
+// the server action. That was the whole problem: the only way to run them was
+// to be a signed-in human clicking Save, so curator scripts wrote rows the
+// form would refuse and nobody found out until an editor tried to fix a typo.
+
+const spec = (key: string) =>
+  [...EDITABLE_FIELDS, ...CURATOR_FIELDS].find((s) => s.key === key)!;
+
+describe("parseField", () => {
+  it("accepts a value inside its limit", () => {
+    const r = parseField(spec("shortName"), "Köthe conjecture", "slug");
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects a value over its limit, counting characters not code units", () => {
+    // Blackboard bold is one character and two UTF-16 units; the limit is in
+    // characters, because that is what the column measures.
+    const s = spec("shortName");
+    const under = "𝔽".repeat(s.maxLength!);
+    const over = "𝔽".repeat(s.maxLength! + 1);
+    expect(parseField(s, under, "slug").ok).toBe(true);
+    expect(parseField(s, over, "slug").ok).toBe(false);
+  });
+
+  it("rejects a choice value that is not an option", () => {
+    const r = parseField(spec("verification"), "vibes-verified", "slug");
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a source URL that is not http(s)", () => {
+    expect(parseField(spec("sourceUrl"), "ftp://x.test/p", "slug").ok).toBe(
+      false,
+    );
+    expect(parseField(spec("sourceUrl"), "https://x.test/p", "slug").ok).toBe(
+      true,
+    );
+  });
+
+  it("rejects a malformed solve date", () => {
+    expect(parseField(spec("solveDate"), "Sept 2026", "slug").ok).toBe(false);
+    expect(parseField(spec("solveDate"), "2026-09", "slug").ok).toBe(true);
+  });
+
+  it("treats an empty optional field as null rather than an error", () => {
+    const r = parseField(spec("verificationNote"), "   ", "slug");
+    expect(r).toEqual({ ok: true, value: null });
+  });
+
+  it("refuses to empty a required field", () => {
+    const r = parseField(spec("shortName"), "   ", "slug");
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("checkStoredEntry", () => {
+  const specs = [...EDITABLE_FIELDS, ...CURATOR_FIELDS];
+
+  it("passes a clean entry", () => {
+    expect(
+      checkStoredEntry({
+        specs,
+        fields: { shortName: "Fine", verification: "unreviewed" },
+        sourceUrl: "https://example.test/paper",
+        links: [{ label: "Lean proof", url: "https://example.test/lean" }],
+      }),
+    ).toEqual([]);
+  });
+
+  it("catches a link that repeats the primary source", () => {
+    // The failure that actually happened, eleven times over. sameDocument
+    // normalises tracking parameters away, so a "?utm_source=chatgpt.com"
+    // copy of the source looks different to a human and identical to the
+    // validator.
+    const v = checkStoredEntry({
+      specs,
+      sourceUrl: "https://claymath.org/wp-content/uploads/navierstokes.pdf",
+      links: [
+        {
+          label: "Clay problem description",
+          url: "https://claymath.org/wp-content/uploads/navierstokes.pdf?utm_source=chatgpt.com",
+        },
+      ],
+    });
+    expect(v).toHaveLength(1);
+    expect(v[0].problem).toMatch(/primary source/);
+  });
+
+  it("catches two links pointing at the same document", () => {
+    const v = checkStoredEntry({
+      specs,
+      links: [
+        { label: "Paper", url: "https://arxiv.org/abs/2609.01234" },
+        { label: "Paper again", url: "https://arxiv.org/abs/2609.01234#s2" },
+      ],
+    });
+    expect(v.some((x) => /duplicate/.test(x.problem))).toBe(true);
+  });
+
+  it("catches an over-length field", () => {
+    const v = checkStoredEntry({
+      specs,
+      fields: { shortName: "x".repeat(1000) },
+    });
+    expect(v).toHaveLength(1);
+    expect(v[0].field).toBe("shortName");
+  });
+
+  it("catches a choice value no longer offered", () => {
+    const v = checkStoredEntry({
+      specs,
+      fields: { resolution: "mostly-solved" },
+    });
+    expect(v.some((x) => x.field === "resolution")).toBe(true);
+  });
+
+  it("catches a link label over 120 characters", () => {
+    const v = checkStoredEntry({
+      specs,
+      links: [{ label: "y".repeat(121), url: "https://example.test/a" }],
+    });
+    expect(v.some((x) => /120/.test(x.problem))).toBe(true);
+  });
+
+  it("ignores fields the caller did not supply", () => {
+    // A script updating two fields should not be told off about the rest of
+    // the entry, which it never touched and cannot see.
+    expect(checkStoredEntry({ specs, fields: { shortName: "Fine" } })).toEqual(
+      [],
+    );
+  });
+});

--- a/src/lib/field-validation.ts
+++ b/src/lib/field-validation.ts
@@ -1,0 +1,225 @@
+// The one implementation of "is this value allowed in this field".
+//
+// It used to live inside the update action, which meant the only way to run
+// it was to be a signed-in human clicking Save. Curator scripts write
+// straight to the database and so ran none of it, and the catalog collected
+// rows the form would refuse. Measured on 10 September 2026 by running this
+// very parser over every stored value: two published entries held a
+// duplicated link, which parseLinks rejects unconditionally, so NO edit to
+// either could save; eleven more held a link repeating the entry's primary
+// source, which the form rejects on submission and whenever the links are
+// edited. One of the two hard cases had been created by a review script the
+// day before.
+//
+// So it lives here, importable by the server actions AND by scripts. A script
+// that writes entry data is expected to call `checkStoredEntry` in its dry run
+// and refuse to write when it fails - the same answer the form would give.
+
+import { canonical, charLength } from "@/lib/char-length";
+import {
+  MAX_LINKS,
+  isHttpUrl,
+  isValidSolveDate,
+  parseLinks,
+  sameDocument,
+  type FieldSpec,
+} from "@/lib/editable";
+import { parseRelations, type RelationRef } from "@/lib/relation-kinds";
+import type { LinkRef } from "@/lib/problems";
+
+/// The database value a form string maps to.
+export type Parsed =
+  string | number | string[] | LinkRef[] | RelationRef[] | null;
+
+export function parseField(
+  spec: FieldSpec,
+  raw: string,
+  ownSlug: string,
+): { ok: true; value: Parsed } | { ok: false; error: string } {
+  // NFC as well as trim, so the value that gets counted below is the value
+  // that gets stored. Without it a decomposed paste is measured one way and
+  // written another, and two spellings of one visible name sit in the
+  // catalog as different strings.
+  const v = canonical(raw.trim());
+
+  if (v === "") {
+    if (spec.required)
+      return { ok: false, error: `${spec.label} cannot be empty.` };
+    const emptyArray =
+      spec.kind === "list" ||
+      spec.kind === "links" ||
+      spec.kind === "relations";
+    return { ok: true, value: emptyArray ? [] : null };
+  }
+
+  // charLength, not v.length: see src/lib/char-length.ts. Counting UTF-16
+  // units refused notes the author had correctly counted as under the cap,
+  // because blackboard bold and friends cost two units each.
+  if (spec.maxLength && charLength(v) > spec.maxLength) {
+    return {
+      ok: false,
+      error: `${spec.label} is too long: ${charLength(v)} characters, max ${spec.maxLength}.`,
+    };
+  }
+
+  if (spec.plainText && v.includes("$")) {
+    return {
+      ok: false,
+      error: `${spec.label} is plain text: write math in ASCII (L^p, n=5) rather than $...$, which renders as raw LaTeX in tabs, feeds and search.`,
+    };
+  }
+
+  switch (spec.kind) {
+    case "choice": {
+      const allowed = (spec.options ?? []).map((o) => o.value);
+      if (!allowed.includes(v)) {
+        return { ok: false, error: `${spec.label} is not a valid option.` };
+      }
+      return { ok: true, value: v };
+    }
+    case "number": {
+      if (!/^\d+$/.test(v))
+        return { ok: false, error: `${spec.label} must be a whole number.` };
+      const n = Number(v);
+      if (spec.key === "yearPosed" && (n < 1000 || n > 3000)) {
+        return { ok: false, error: "Year posed must be a four-digit year." };
+      }
+      return { ok: true, value: n };
+    }
+    case "url":
+      if (!isHttpUrl(v))
+        return {
+          ok: false,
+          error: `${spec.label} must start with http:// or https://.`,
+        };
+      return { ok: true, value: v };
+    case "list":
+      return {
+        ok: true,
+        value: v
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      };
+    case "links":
+      return parseLinks(v);
+    case "relations":
+      return parseRelations(v, ownSlug);
+    case "text":
+    case "textarea":
+      if (spec.key === "solveDate" && !isValidSolveDate(v)) {
+        return {
+          ok: false,
+          error: "Solve date must be YYYY, YYYY-MM or YYYY-MM-DD.",
+        };
+      }
+      return { ok: true, value: v };
+  }
+}
+
+/// A violation of the rules the edit form enforces, found in data that is
+/// already stored.
+export interface StoredViolation {
+  field: string;
+  problem: string;
+}
+
+/**
+ * Check an entry's stored values the way the form would.
+ *
+ * Scripts call this before writing so they cannot leave behind a row that
+ * the UI will later refuse to save. It takes values as they are stored,
+ * rather than as form strings, because that is what a script has.
+ */
+export function checkStoredEntry(input: {
+  fields?: Record<string, unknown>;
+  specs?: FieldSpec[];
+  links?: { label: string; url: string }[];
+  sourceUrl?: string | null;
+}): StoredViolation[] {
+  const out: StoredViolation[] = [];
+  const { fields = {}, specs = [], links, sourceUrl } = input;
+
+  for (const spec of specs) {
+    const v = fields[spec.key];
+    if (v === undefined) continue;
+    if (v === null || v === "") {
+      if (spec.required)
+        out.push({ field: spec.key, problem: "required but empty" });
+      continue;
+    }
+    if (typeof v === "string") {
+      const n = charLength(canonical(v));
+      if (spec.maxLength && n > spec.maxLength)
+        out.push({
+          field: spec.key,
+          problem: `${n} characters, max ${spec.maxLength}`,
+        });
+      if (spec.plainText && v.includes("$"))
+        out.push({ field: spec.key, problem: "plain-text field contains $" });
+      if (spec.kind === "choice") {
+        const allowed = (spec.options ?? []).map((o) => o.value);
+        if (!allowed.includes(v))
+          out.push({
+            field: spec.key,
+            problem: `"${v}" is not an allowed option`,
+          });
+      }
+      if (spec.kind === "url" && !isHttpUrl(v))
+        out.push({ field: spec.key, problem: "not an http(s) URL" });
+      if (spec.key === "solveDate" && !isValidSolveDate(v))
+        out.push({
+          field: spec.key,
+          problem: "not YYYY, YYYY-MM or YYYY-MM-DD",
+        });
+    }
+    if (
+      typeof v === "number" &&
+      spec.key === "yearPosed" &&
+      (v < 1000 || v > 3000)
+    )
+      out.push({ field: spec.key, problem: "not a four-digit year" });
+  }
+
+  // Links carry the rules that actually bit: a link may not repeat the
+  // primary source, and no two links may point at the same document. Both
+  // compare by `sameDocument`, which normalises away tracking parameters -
+  // which is how a "?utm_source=..." copy of the primary source slipped in
+  // looking different.
+  if (links) {
+    if (links.length > MAX_LINKS)
+      out.push({
+        field: "links",
+        problem: `${links.length} links, max ${MAX_LINKS}`,
+      });
+    const seen: string[] = [];
+    for (const l of links) {
+      if (!l.label || l.label.length > 120)
+        out.push({
+          field: "links",
+          problem: `label ${l.label.length}/120: "${l.label.slice(0, 40)}"`,
+        });
+      if (!isHttpUrl(l.url))
+        out.push({
+          field: "links",
+          problem: `not an http(s) URL: "${l.url.slice(0, 40)}"`,
+        });
+      if (sourceUrl && sameDocument(l.url, sourceUrl))
+        out.push({
+          field: "links",
+          problem: `repeats the primary source: "${l.label.slice(0, 40)}"`,
+        });
+      if (seen.some((s) => sameDocument(s, l.url)))
+        out.push({
+          field: "links",
+          problem: `duplicate of another link: "${l.label.slice(0, 40)}"`,
+        });
+      seen.push(l.url);
+    }
+  }
+  return out;
+}
+
+/// `parseLinks` re-exported so a script can validate a link set exactly as
+/// the form parses it, rather than approximating.
+export { parseLinks };

--- a/src/lib/scripts-use-guard.test.ts
+++ b/src/lib/scripts-use-guard.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Curator scripts write to production. For a month they did so through a bare
+// PrismaClient that ran none of the rules the edit form enforces, and the
+// catalog collected rows the form refuses - twelve published entries could not
+// be saved by anyone on 10 September 2026. scripts/lib/guarded-prisma.ts puts
+// the form's validator in the write path; this test makes using it the rule
+// rather than the convention, by failing the build for any script that
+// constructs its own client.
+//
+// The allowlist is every script that existed when the guard was introduced.
+// They have all already run against production and are kept as the record of
+// what was done and why; rewriting them would change history for no gain.
+// Nothing is added to this list. A new script imports guardedPrisma.
+
+const ROOT = join(__dirname, "..", "..");
+const SCRIPTS = join(ROOT, "scripts");
+
+const RAN_BEFORE_THE_GUARD = new Set([
+  "add-alpoge-buckmaster-2026-09-08.ts",
+  "add-ame-five-cases.ts",
+  "add-erdos-501.ts",
+  "add-ffd-no-degeneracies.ts",
+  "add-lyons-white-2026-09-06.ts",
+  "add-matmul-exponent.ts",
+  "add-tilted-prime-gaps.ts",
+  "amend-buffon-ai-axis.ts",
+  "amend-dihedral-ramsey.ts",
+  "amend-erdos-424-green.ts",
+  "amend-petersen-priority.ts",
+  "answer-186-report-2026-09-05.ts",
+  "audit-field-lengths.ts",
+  "audit-paren-delimiters.ts",
+  "check-comment-render.ts",
+  "check-editable-fields.ts",
+  "check-field-limits.ts",
+  "check-ids.ts",
+  "check-notability.ts",
+  "check-source-links.ts",
+  "confirm-conway-2026-09-04.ts",
+  "confirm-mul4-2026-09-03.ts",
+  "copy-frontiers-to-production-2026-09-05.ts",
+  "correct-percolation-2026-09-04.ts",
+  "credit-leder-2026-09-08.ts",
+  "demote-186-row-2026-09-05.ts",
+  "dump-pending.ts",
+  "export-problems.ts",
+  "fill-significance-2026-08-12.ts",
+  "fix-duplicate-source-links.ts",
+  "fix-latex-titles.ts",
+  "fix-link-rules.ts",
+  "fix-math-shortnames.ts",
+  "fix-mul4-date-2026-09-02.ts",
+  "fix-percolation-tex-2026-09-08.ts",
+  "fix-prime-gaps-dollar.ts",
+  "fix-tooltip-math.ts",
+  "fix-werner-concurrent.ts",
+  "fix-ytd-method.ts",
+  "frame-dynamo-variants.ts",
+  "handle-invgen-v2.ts",
+  "handle-zeta-report-2026-09-03.ts",
+  "hold-ytd-2026-09-02.ts",
+  "import-alpoge-s6.ts",
+  "import-bounded-gaps-2026-09-04.ts",
+  "import-elliptic-rank-30.ts",
+  "import-elliptic-rank-31.ts",
+  "import-sweep-2026-08-12.ts",
+  "import-sweep-2026-08-13.ts",
+  "import-sweep-2026-08-17.ts",
+  "import-sweep-2026-08-21.ts",
+  "inbox-2026-09-05.ts",
+  "inbox-replies-2026-09-10.ts",
+  "add-c11-frontier-2026-09-10.ts",
+  "fix-c11-frontier-name-2026-09-10.ts",
+  "liu-notes-2026-09-02.ts",
+  "reclassify-announcements.ts",
+  "reject-levy-montague.ts",
+  "reject-m23.ts",
+  "reject-tournament-quotients-ii.ts",
+  "rename-gap-records-2026-09-04.ts",
+  "reply-hiddenhawk-wiki.ts",
+  "reply-vibegene-ytd-method.ts",
+  "reply-zestywombat.ts",
+  "restate-ssuf-part3.ts",
+  "restore-latex-names.ts",
+  "review-2026-09-01.ts",
+  "review-2026-09-02.ts",
+  "review-2026-09-03-b.ts",
+  "review-2026-09-03.ts",
+  "review-2026-09-04-b.ts",
+  "review-2026-09-04-c.ts",
+  "review-2026-09-04-d.ts",
+  "review-2026-09-04.ts",
+  "review-2026-09-05-b.ts",
+  "review-2026-09-05.ts",
+  "review-2026-09-06.ts",
+  "review-2026-09-08-b.ts",
+  "review-2026-09-08.ts",
+  "review-2026-09-09.ts",
+  "review-albertson-berman.ts",
+  "review-batch-2026-08-12.ts",
+  "review-batch-2026-08-17.ts",
+  "review-batch-28aug-pm.ts",
+  "review-batch-28aug.ts",
+  "review-bounded-mass-property.ts",
+  "review-buffon-full-chord.ts",
+  "review-caratheodory-smooth.ts",
+  "review-composites-seven-followup.ts",
+  "review-dean-k5.ts",
+  "review-dihedral-ramsey.ts",
+  "review-dt-loop-quiver.ts",
+  "review-dubickas-problem-3.ts",
+  "review-erdos-270-affine.ts",
+  "review-erdos-390.ts",
+  "review-erdos-kac-palindromes.ts",
+  "review-gamow-liquid-drop.ts",
+  "review-gardner-transition.ts",
+  "review-girth5-spin-mixing.ts",
+  "review-gromov-volume-growth.ts",
+  "review-hadamard-668.ts",
+  "review-haglund-k1.ts",
+  "review-intree-conjugation.ts",
+  "review-keisler-generic-stability.ts",
+  "review-lattice-paths.ts",
+  "review-local-limits-squares.ts",
+  "review-m23-resubmission.ts",
+  "review-nevanlinna-half-plane.ts",
+  "review-petersen-coloring.ts",
+  "review-phelps-rodriguez.ts",
+  "review-prime-digital-functions.ts",
+  "review-rademacher-fourth-moment.ts",
+  "review-rado-40c41.ts",
+  "review-rado-general.ts",
+  "review-ramsey-19values.ts",
+  "review-ramsey-a4.ts",
+  "review-random-assignment-clt.ts",
+  "review-riviere-n-laplace.ts",
+  "review-scl-one-relator.ts",
+  "review-sendov.ts",
+  "review-smooth-random-dynamo.ts",
+  "review-sop23.ts",
+  "review-sparse-convex-body.ts",
+  "review-ssuf-part3.ts",
+  "review-stein-riesz.ts",
+  "review-subdl-signed-depth.ts",
+  "review-talagrand-convolution.ts",
+  "review-talagrand-sk.ts",
+  "review-teschner.ts",
+  "review-three-summand-plateau.ts",
+  "review-three-summand-tu-deng.ts",
+  "review-u30-autocorrelation.ts",
+  "seed-record-small-gaps-2026-09-04.ts",
+  "seed-records-2026-09-04.ts",
+  "seed-records-batch2-2026-09-05.ts",
+  "seed-relations-2026-08-13.ts",
+  "set-team-2026-09-02.ts",
+  "shorten-over-limit-fields.ts",
+  "update-borsuk-priority.ts",
+  "update-crouzeix-jin.ts",
+  "update-dean-k5-replayed.ts",
+  "update-gromov-third-proof.ts",
+  "update-hadamard-668.ts",
+  "update-haglund-replay-confirmed.ts",
+  "update-prime-gaps-expert.ts",
+  "update-zeta-arxiv.ts",
+  // Infrastructure, not entry data: one renamed a table, one toggles the
+  // CockroachDB schema lock. Neither writes a Problem or a ProblemLink.
+  "rename-records-to-frontiers.mjs",
+  "schema-lock.mjs",
+]);
+
+const BARE_CLIENT = /new\s+PrismaClient\s*\(/;
+
+describe("curator scripts write through the guarded client", () => {
+  const files = readdirSync(SCRIPTS).filter(
+    (f) => (f.endsWith(".ts") || f.endsWith(".mjs")) && !f.startsWith("_"),
+  );
+
+  it("finds the scripts directory", () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  for (const f of files) {
+    if (RAN_BEFORE_THE_GUARD.has(f)) continue;
+    it(`${f} does not construct its own PrismaClient`, () => {
+      const src = readFileSync(join(SCRIPTS, f), "utf8");
+      if (BARE_CLIENT.test(src)) {
+        throw new Error(
+          `${f} constructs a bare PrismaClient. Import guardedPrisma from ` +
+            `scripts/lib/guarded-prisma.ts instead, so the form's validation ` +
+            `runs before anything is written. A script that bypasses it can ` +
+            `leave an entry nobody can edit.`,
+        );
+      }
+    });
+  }
+
+  it("the guard itself is the only place a bare client is constructed", () => {
+    const src = readFileSync(join(SCRIPTS, "lib", "guarded-prisma.ts"), "utf8");
+    expect(BARE_CLIENT.test(src)).toBe(true);
+  });
+});


### PR DESCRIPTION
Releases #59. One squashed commit, one behaviour change in runtime code, and the deploy that finally makes three days of database writes visible.

## The runtime change

`src/app/actions/update-problem.ts` validated every field the edit form posts, including fields the editor never touched, **before** checking whether the value had changed. One bad stored value therefore made an entry permanently uneditable: you opened it to fix a typo and got an error about a link you had not opened.

Untouched fields are now skipped *before* they are validated. Changing a bad value still has to make it valid.

Measured across all 706 published entries by running the form's own parser over every stored value: 2 entries were hard-blocked (a duplicated link, which `parseLinks` refuses whatever else you change), and 11 more carried a link repeating their primary source, which blocked any link edit and refused the entry on submission. All 13 violations were cleared in the database on 10 September; this ships the code half.

## Why it happened, and what stops it recurring

`parseField` lived inside a `"use server"` action, so the only way to run it was to be a signed-in human clicking Save. Curator scripts wrote straight to the database and ran none of it.

- **`src/lib/field-validation.ts`** - the parser, importable by actions and scripts, and testable for the first time.
- **`scripts/lib/guarded-prisma.ts`** - wraps `PrismaClient` so `problem.create/update/upsert` and `problemLink.create/update` run the form's checks against the **merged** result and refuse with the field and rule named. Raw `INSERT`/`UPDATE` on those two tables is refused outright; `SELECT`/`DELETE` stay open.
- **`src/lib/scripts-use-guard.test.ts`** - fails the build if any script under `scripts/` constructs a bare `PrismaClient`.
- **`scripts/audit-editability.ts`** - runs the real parser over every published entry and exits non-zero on a hard block.

## What the deploy makes visible

Everything below is already in the production database and is currently served stale, because a direct write revalidates no cache tag. This deploy clears it.

- **A new frontier**: upper bounds on the de Bruijn-Newman constant, six rows.
- **Three new entries**: Hilbert-UMD sharpness (Lean-verified), the entropy-method ceiling for union-closed (Lean-checked), subDMQ arithmetic is trivial. Plus xi normality from two days earlier.
- **Corrected ages**: Navier-Stokes dated from Leray 1934 rather than the 2000 Clay prize (26 years -> 92), and Euler blowup from Lichtenstein 1925 (26 -> 101).
- **Two entries held** under the extraordinary-claims rule, and one declined.
- **18 contact messages answered**, one profile verified, one frontier wording fix.

## Verification

- 156 tests, `npm run typecheck` and `npm run lint` clean.
- `audit-editability` against production: 0 hard blocks.

## Manual check after deploy

Open `prime-gaps-at-most-186`, change one word in the title, save. Before this it failed with a message about links; after it, it succeeds.

Then spot-check that the lists have caught up: `/frontiers` should show the de Bruijn-Newman staircase, and the significance-vs-age scatter on `/stats` should place Navier-Stokes at 92 years rather than 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dTNYAzs4dDcgrjTNx6W4N
